### PR TITLE
Update mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ compileJava {
 }
 
 minecraft {
-    version = "1.12-14.21.0.2322"
+    version = "1.12-14.21.0.2363"
     runDir = "run"
     
     // the mappings can be changed at any time, and must be in the following format.
@@ -29,7 +29,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20161220"
+    mappings = "snapshot_20170625"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 


### PR DESCRIPTION
Update Forge version and mappings to a well tested and 'stable' version.
This fixes a deobfMcMCP error: 
`java.util.zip.ZipException: duplicate entry: net/minecraft/command/AdvancementCommand$Mode.class`