### PR TITLE
Load thaumcraft as early as possible

### DIFF
--- a/src/main/java/growthcraft/grapes/GrowthcraftGrapes.java
+++ b/src/main/java/growthcraft/grapes/GrowthcraftGrapes.java
@@ -43,6 +43,9 @@ public class GrowthcraftGrapes {
 		Init.preInitFluids();
 
 		proxy.preInit();
+		if (Compat.isModAvailable_Thaumcraft()) {
+			GrapesAspectRegistry.register();
+		}
 	}
 
 	@Mod.EventHandler
@@ -53,9 +56,6 @@ public class GrowthcraftGrapes {
 			Recipes.initBoozes();
 		Init.initRecipes();
 		Init.registerRecipes();
-		if (Compat.isModAvailable_Thaumcraft()) {
-			GrapesAspectRegistry.register();
-		}
 	}
 
 	@Mod.EventHandler


### PR DESCRIPTION
This should solve some known derpiness with Thaumcraft. You can even now get away with new aspects, since mods like modtweaker won't have an aneurysm anymore.

Load thaumcraft in the preinit phase, thaumcraft likes to be first.