### PR TITLE
Bounding boxes fixes and improvements

### DIFF
--- a/TODOs.txt
+++ b/TODOs.txt
@@ -20,11 +20,10 @@ Bugs:
 BUG: Client and Server synchronisation for brewing kettle is not working unless the user opens the GUI. Possible other devices are impacted.
 BUG: Bee box has a spamming block update.
 BUG: Cheese press is triggered when placing a neighbor block.
-BUG: Effect duration in Detail window appears to be wrong. E.g. for Skim Milk. 
 BUG: Filling bottles with booze bucket always returning juice. Reason: NBTtags of UniversalBucket in class ShapelessRecipes not compared. 
-BUG: Collision boxes for brewing kettle walls are not correct.
 BUG: No kind of block sounds, like fruit press pistons, splash sound when dropping items into brewing kettle a.s.o.
 BUG: Fix string formatting with arguments when logging.
+DONE: Collision boxes for brewing kettle walls are not correct.
 DONE: Thistle recipe not working to get seeds.
 DONE: Ricotta bowl recipe not working.
 DONE: Grape Leaves are removed, too, if a trunk has been removed.
@@ -32,6 +31,7 @@ DONE: Cheese rotation needs to be fixed.
 DONE: BUG: Tipsy Effect not saved when game is saved.
 DONE: BUG: No Tipsy Effect icon. 
 NOTABUG: BUG: Booze color is too dark.
+NOTABUG: BUG: Effect duration in Detail window appears to be wrong. E.g. for Skim Milk. 
 
 -----------------
 Potential Bugs:
@@ -44,7 +44,7 @@ Improvements:
 -----------------
 TODO: Heat blocks to react on meta and supporting neighborChanged events for tiles. For heat blocks which can be turned on/off.
 TODO: Only accepted items are consumed, thrown into brewing kettle 
-TODO: isItemValid for culture jar container
+DONE: isItemValid for culture jar container
 DONE: isItemValid for fermenting barrel container
 DONE: No whey production for dried curds over pancheons, in order to stop an infinite source of whey. 
 DONE: Fruit Press fluid render.
@@ -55,13 +55,13 @@ Not ported stuff:
 -----------------
 TODO: Missing translations.
 TODO: Mining levels for all ported devices.
-TODO: Real curds textures and models.
-TODO: Crafting Recipes for Cellar.
-TODO: Crafting Recipes for Milk.
 TODO: Crafting Recipes for Core.
-TODO: Crafting Recipes for Grapes.
-TODO: Crafting Recipes for Hops.
 TODO: Booze Fluid behavior like bubbles etc.
+DONE: Real curds textures and models.
+DONE: Crafting Recipes for Cellar.
+DONE: Crafting Recipes for Milk.
+DONE: Crafting Recipes for Grapes.
+DONE: Crafting Recipes for Hops.
 DONE: Add food ore dictionary: apple, grape
 DONE: Cheese model items to be textured.
 DONE: Curds textures and models.
@@ -104,13 +104,13 @@ DONE: Add Grapewine name enum.
 ------------
 Porting to 1.12.2:
 ------------
-TODO: Port recipes.
 TODO: Add cellar Advancements.
 TODO: Handle alpha for tile entity rendering.
 TODO: Reenable Bucket to bottle filling for boozes.
 TODO: BUG: Recipes using custom classes are displayed as empty.
-TODO: BUG: Honey jar recipe with bucket is broken.
-TODO: BUG: Crowbar is displayed in the slot for erasing items at Creative GUI.
+DONE: BUG: Honey jar recipe with bucket is broken.
+DONE: BUG: Crowbar is displayed in the slot for erasing items at Creative GUI.
+DONE: Port recipes.
 DONE: BUG: Right shift+clicking an item in inventory doesn't redraw GUI. 
 
 ------------

--- a/src/main/java/growthcraft/cellar/common/block/BlockBrewKettle.java
+++ b/src/main/java/growthcraft/cellar/common/block/BlockBrewKettle.java
@@ -52,20 +52,20 @@ public class BlockBrewKettle extends BlockCellarContainer {
             0.0625 * 0, 0.0625 * 0, 0.0625 * 0,
             0.0625 * 16, 0.0625 * 4, 0.0625 * 16);
     private static final AxisAlignedBB AABB_WALL_NORTH = new AxisAlignedBB(
-            0.0625 * 14, 0.0625 * 0, 0.0625 * 0,
-            0.0625 * 16, 0.0625 * 16, 0.0625 * 16);
+            0.0625 * 0, 0.0625 * 0, 0.0625 * 0,
+            0.0625 * 16, 0.0625 * 16, 0.0625 * 2);
     private static final AxisAlignedBB AABB_WALL_EAST = new AxisAlignedBB(
             0.0625 * 14, 0.0625 * 0, 0.0625 * 0,
             0.0625 * 16, 0.0625 * 16, 0.0625 * 16);
     private static final AxisAlignedBB AABB_WALL_SOUTH = new AxisAlignedBB(
             0.0625 * 0, 0.0625 * 0, 0.0625 * 14,
-            0.0625 * 2, 0.0625 * 16, 0.0625 * 16);
+            0.0625 * 16, 0.0625 * 16, 0.0625 * 16);
     private static final AxisAlignedBB AABB_WALL_WEST = new AxisAlignedBB(
             0.0625 * 0, 0.0625 * 0, 0.0625 * 0,
             0.0625 * 2, 0.0625 * 16, 0.0625 * 16);
     private static final AxisAlignedBB AABB_LID = new AxisAlignedBB(
             0.0625 * 2, 0.0625 * 14, 0.0625 * 2,
-            0.0625 * 2, 0.0625 * 16, 0.0625 * 2);
+            0.0625 * 14, 0.0625 * 16, 0.0625 * 14);
 
     public BlockBrewKettle(String unlocalizedName) {
         super(Material.IRON);
@@ -182,12 +182,16 @@ public class BlockBrewKettle extends BlockCellarContainer {
 
 	@SuppressWarnings("deprecation")
     @Override
-    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean p_185477_7_) {
-        addCollisionBoxToList(pos, entityBox, collidingBoxes, AABB_BASE);
+    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean isActualState) {
+        if( !isActualState )
+        	state = state.getActualState(worldIn, pos);
+		
+		addCollisionBoxToList(pos, entityBox, collidingBoxes, AABB_BASE);
         addCollisionBoxToList(pos, entityBox, collidingBoxes, AABB_WALL_NORTH);
         addCollisionBoxToList(pos, entityBox, collidingBoxes, AABB_WALL_EAST);
         addCollisionBoxToList(pos, entityBox, collidingBoxes, AABB_WALL_SOUTH);
         addCollisionBoxToList(pos, entityBox, collidingBoxes, AABB_WALL_WEST);
+        
         if( state.getValue(TYPE_LID).booleanValue() )
         	addCollisionBoxToList(pos, entityBox, collidingBoxes, AABB_LID);
     }

--- a/src/main/java/growthcraft/core/common/block/BlockRopeBase.java
+++ b/src/main/java/growthcraft/core/common/block/BlockRopeBase.java
@@ -1,0 +1,62 @@
+package growthcraft.core.common.block;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import growthcraft.core.shared.block.IBlockRope;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+public abstract class BlockRopeBase extends Block implements IBlockRope {
+
+    public static final PropertyBool NORTH = PropertyBool.create("north");
+    public static final PropertyBool EAST = PropertyBool.create("east");
+    public static final PropertyBool SOUTH = PropertyBool.create("south");
+    public static final PropertyBool WEST = PropertyBool.create("west");
+    public static final PropertyBool UP = PropertyBool.create("up");
+    public static final PropertyBool DOWN = PropertyBool.create("down");
+
+	public BlockRopeBase(Material materialIn) {
+		super(materialIn);
+	}
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
+    	ArrayList<AxisAlignedBB> collidingBoxes = new ArrayList<>(5);
+    	
+    	state = state.getActualState(source, pos);
+    	populateCollisionBoxes(state, pos, FULL_BLOCK_AABB.offset(pos), collidingBoxes);
+    	if( collidingBoxes.isEmpty() )
+    		return FULL_BLOCK_AABB;
+    	
+    	AxisAlignedBB box = collidingBoxes.get(0);	// NOTE: Assuming that collidingBoxes is non empty!
+    	for( int i = 1; i < collidingBoxes.size(); i ++ )
+    		box = box.union(collidingBoxes.get(i));
+    	box = box.offset(new BlockPos(-pos.getX(), -pos.getY(), -pos.getZ()));
+    	
+    	return box;
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean isActualState) {
+        if( !isActualState )
+        	state = state.getActualState(worldIn, pos);
+        
+        populateCollisionBoxes(state, pos, entityBox, collidingBoxes);
+    }
+	
+	protected abstract void populateCollisionBoxes(IBlockState actualState, BlockPos pos, AxisAlignedBB entityBox,
+			List<AxisAlignedBB> collidingBoxes);
+
+}

--- a/src/main/java/growthcraft/core/common/block/BlockRopeFence.java
+++ b/src/main/java/growthcraft/core/common/block/BlockRopeFence.java
@@ -1,5 +1,6 @@
 package growthcraft.core.common.block;
 
+import java.util.List;
 import java.util.Random;
 
 import growthcraft.core.shared.Reference;
@@ -20,17 +21,16 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-public class BlockRopeFence extends Block implements IBlockRope {
+public class BlockRopeFence extends BlockRopeBase {
 
     private static final AxisAlignedBB KNOT_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 7, 0.0625 * 7, 0.0625 * 7, 0.0625 * 9, 0.0625 * 9, 0.0625 * 9);
-
-    public static final PropertyBool NORTH = PropertyBool.create("north");
-    public static final PropertyBool EAST = PropertyBool.create("east");
-    public static final PropertyBool SOUTH = PropertyBool.create("south");
-    public static final PropertyBool WEST = PropertyBool.create("west");
-    public static final PropertyBool UP = PropertyBool.create("up");
-    public static final PropertyBool DOWN = PropertyBool.create("down");
-
+    private static final AxisAlignedBB NORTH_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 7, 0.0625 * 7, 0.0625 * 0, 0.0625 * 9, 0.0625 * 9, 0.0625 * 7);
+    private static final AxisAlignedBB EAST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 9, 0.0625 * 7, 0.0625 * 7, 0.0625 * 16, 0.0625 * 9, 0.0625 * 9);
+    private static final AxisAlignedBB SOUTH_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 7, 0.0625 * 7, 0.0625 * 9, 0.0625 * 9, 0.0625 * 9, 0.0625 * 16);
+    private static final AxisAlignedBB WEST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 0, 0.0625 * 7, 0.0625 * 7, 0.0625 * 7, 0.0625 * 9, 0.0625 * 9);
+    private static final AxisAlignedBB UP_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 7, 0.0625 * 9, 0.0625 * 7, 0.0625 * 9, 0.0625 * 16, 0.0625 * 9);
+    private static final AxisAlignedBB DOWN_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 7, 0.0625 * 0, 0.0625 * 7, 0.0625 * 9, 0.0625 * 7, 0.0625 * 9);
+    
     public BlockRopeFence(String unlocalizedName) {
         super(Material.CARPET);
         this.setUnlocalizedName(unlocalizedName);
@@ -45,10 +45,22 @@ public class BlockRopeFence extends Block implements IBlockRope {
                 .withProperty(DOWN, Boolean.valueOf(false)));
     }
 
-    @SuppressWarnings("deprecation")
     @Override
-    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
-        return KNOT_BOUNDING_BOX;
+    protected void populateCollisionBoxes(IBlockState actualState, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes) {
+    	addCollisionBoxToList(pos, entityBox, collidingBoxes, KNOT_BOUNDING_BOX);
+    	
+    	if( actualState.getValue(NORTH) )
+    		addCollisionBoxToList(pos, entityBox, collidingBoxes, NORTH_BOUNDING_BOX);
+    	if( actualState.getValue(EAST) )
+    		addCollisionBoxToList(pos, entityBox, collidingBoxes, EAST_BOUNDING_BOX);
+    	if( actualState.getValue(SOUTH) )
+    		addCollisionBoxToList(pos, entityBox, collidingBoxes, SOUTH_BOUNDING_BOX);
+    	if( actualState.getValue(WEST) )
+    		addCollisionBoxToList(pos, entityBox, collidingBoxes, WEST_BOUNDING_BOX);
+    	if( actualState.getValue(UP) )
+    		addCollisionBoxToList(pos, entityBox, collidingBoxes, UP_BOUNDING_BOX);
+    	if( actualState.getValue(DOWN) )
+    		addCollisionBoxToList(pos, entityBox, collidingBoxes, DOWN_BOUNDING_BOX);
     }
 
     @Override

--- a/src/main/java/growthcraft/core/common/block/BlockRopeFence.java
+++ b/src/main/java/growthcraft/core/common/block/BlockRopeFence.java
@@ -7,6 +7,7 @@ import growthcraft.core.shared.Reference;
 import growthcraft.core.shared.block.IBlockRope;
 import growthcraft.core.shared.init.GrowthcraftCoreItems;
 import net.minecraft.block.Block;
+import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.BlockFaceShape;
@@ -36,6 +37,7 @@ public class BlockRopeFence extends BlockRopeBase {
         this.setUnlocalizedName(unlocalizedName);
         this.setRegistryName(new ResourceLocation(Reference.MODID, unlocalizedName));
         this.setHardness(0.5F);
+        this.setSoundType(SoundType.CLOTH);
         this.setDefaultState(this.blockState.getBaseState()
                 .withProperty(NORTH, Boolean.valueOf(false))
                 .withProperty(EAST, Boolean.valueOf(false))

--- a/src/main/java/growthcraft/core/common/block/BlockRopeKnot.java
+++ b/src/main/java/growthcraft/core/common/block/BlockRopeKnot.java
@@ -48,7 +48,7 @@ public class BlockRopeKnot extends BlockRopeBase implements ITileEntityProvider 
 
         this.setHardness(3);
         this.setResistance(20);
-        this.setSoundType(SoundType.CLOTH);
+        this.setSoundType(SoundType.WOOD);
         this.setHarvestLevel("axe", 0);
 
         this.setDefaultState(this.blockState.getBaseState()

--- a/src/main/java/growthcraft/core/common/block/BlockRopeKnot.java
+++ b/src/main/java/growthcraft/core/common/block/BlockRopeKnot.java
@@ -1,6 +1,5 @@
 package growthcraft.core.common.block;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
@@ -14,11 +13,8 @@ import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.PropertyBool;
-import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.InventoryHelper;
 import net.minecraft.item.ItemStack;
@@ -38,10 +34,10 @@ public class BlockRopeKnot extends BlockRopeBase implements ITileEntityProvider 
 	private static final AxisAlignedBB FENCE_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 6, 0.0625 * 0, 0.0625 * 6, 0.0625 * 10, 0.0625 * 16, 0.0625 * 10);
 	
     private static final AxisAlignedBB KNOT_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 5, 0.0625 * 6, 0.0625 * 5, 0.0625 * 11, 0.0625 * 14, 0.0625 * 11);
-    private static final AxisAlignedBB NORTH_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 5, 0.0625 * 6, 0.0625 * 0, 0.0625 * 11, 0.0625 * 14, 0.0625 * 5);
-    private static final AxisAlignedBB EAST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 11, 0.0625 * 6, 0.0625 * 5, 0.0625 * 16, 0.0625 * 14, 0.0625 * 11);
-    private static final AxisAlignedBB SOUTH_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 5, 0.0625 * 6, 0.0625 * 11, 0.0625 * 11, 0.0625 * 14, 0.0625 * 16);
-    private static final AxisAlignedBB WEST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 0, 0.0625 * 6, 0.0625 * 5, 0.0625 * 5, 0.0625 * 14, 0.0625 * 11);
+	private static final AxisAlignedBB NORTH_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 7, 0.0625 * 7, 0.0625 * 0, 0.0625 * 9, 0.0625 * 9, 0.0625 * 5);
+    private static final AxisAlignedBB EAST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 11, 0.0625 * 7, 0.0625 * 7, 0.0625 * 16, 0.0625 * 9, 0.0625 * 9);
+    private static final AxisAlignedBB SOUTH_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 7, 0.0625 * 7, 0.0625 * 11, 0.0625 * 9, 0.0625 * 9, 0.0625 * 16);
+    private static final AxisAlignedBB WEST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 0, 0.0625 * 7, 0.0625 * 7, 0.0625 * 5, 0.0625 * 9, 0.0625 * 9);
 
     private boolean wasActivated;
 
@@ -92,6 +88,8 @@ public class BlockRopeKnot extends BlockRopeBase implements ITileEntityProvider 
     		addCollisionBoxToList(pos, entityBox, collidingBoxes, SOUTH_BOUNDING_BOX);
     	if( actualState.getValue(WEST) )
     		addCollisionBoxToList(pos, entityBox, collidingBoxes, WEST_BOUNDING_BOX);
+    	
+    	// Up and down not necessary, because they are covered by FENCE_BOUNDING_BOX
     }
 
     @Override

--- a/src/main/java/growthcraft/core/common/block/BlockRopeKnot.java
+++ b/src/main/java/growthcraft/core/common/block/BlockRopeKnot.java
@@ -33,7 +33,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
-public class BlockRopeKnot extends Block implements ITileEntityProvider, IBlockRope {
+public class BlockRopeKnot extends BlockRopeBase implements ITileEntityProvider {
 
 	private static final AxisAlignedBB FENCE_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 6, 0.0625 * 0, 0.0625 * 6, 0.0625 * 10, 0.0625 * 16, 0.0625 * 10);
 	
@@ -42,13 +42,6 @@ public class BlockRopeKnot extends Block implements ITileEntityProvider, IBlockR
     private static final AxisAlignedBB EAST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 11, 0.0625 * 6, 0.0625 * 5, 0.0625 * 16, 0.0625 * 14, 0.0625 * 11);
     private static final AxisAlignedBB SOUTH_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 5, 0.0625 * 6, 0.0625 * 11, 0.0625 * 11, 0.0625 * 14, 0.0625 * 16);
     private static final AxisAlignedBB WEST_BOUNDING_BOX = new AxisAlignedBB(0.0625 * 0, 0.0625 * 6, 0.0625 * 5, 0.0625 * 5, 0.0625 * 14, 0.0625 * 11);
-
-    public static final PropertyBool NORTH = PropertyBool.create("north");
-    public static final PropertyBool EAST = PropertyBool.create("east");
-    public static final PropertyBool SOUTH = PropertyBool.create("south");
-    public static final PropertyBool WEST = PropertyBool.create("west");
-    public static final PropertyBool UP = PropertyBool.create("up");
-    public static final PropertyBool DOWN = PropertyBool.create("down");
 
     private boolean wasActivated;
 
@@ -86,34 +79,8 @@ public class BlockRopeKnot extends Block implements ITileEntityProvider, IBlockR
         return false;
     }
     
-    @SuppressWarnings("deprecation")
     @Override
-    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
-    	ArrayList<AxisAlignedBB> collidingBoxes = new ArrayList<>(5);
-    	
-    	state = state.getActualState(source, pos);
-    	populateCollisionBoxes(state, pos, FULL_BLOCK_AABB.offset(pos), collidingBoxes);
-    	if( collidingBoxes.isEmpty() )
-    		return FULL_BLOCK_AABB;
-    	
-    	AxisAlignedBB box = collidingBoxes.get(0);	// NOTE: Assuming that collidingBoxes is non empty!
-    	for( int i = 1; i < collidingBoxes.size(); i ++ )
-    		box = box.union(collidingBoxes.get(i));
-    	box = box.offset(new BlockPos(-pos.getX(), -pos.getY(), -pos.getZ()));
-    	
-    	return box;
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes, @Nullable Entity entityIn, boolean isActualState) {
-        if( !isActualState )
-        	state = state.getActualState(worldIn, pos);
-        
-        populateCollisionBoxes(state, pos, entityBox, collidingBoxes);
-    }
-    
-    private void populateCollisionBoxes(IBlockState actualState, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes) {
+    protected void populateCollisionBoxes(IBlockState actualState, BlockPos pos, AxisAlignedBB entityBox, List<AxisAlignedBB> collidingBoxes) {
     	addCollisionBoxToList(pos, entityBox, collidingBoxes, FENCE_BOUNDING_BOX);
     	addCollisionBoxToList(pos, entityBox, collidingBoxes, KNOT_BOUNDING_BOX);
     	

--- a/src/main/java/growthcraft/milk/common/block/BlockThistle.java
+++ b/src/main/java/growthcraft/milk/common/block/BlockThistle.java
@@ -27,7 +27,11 @@ import javax.annotation.Nullable;
 
 public class BlockThistle extends BlockCrops implements IGrowable, IPlantable {
 
-    private static final AxisAlignedBB BOUNDING_BOX = new AxisAlignedBB(0.0625 * 4, 0.0625 * 0, 0.0625 * 4, 0.0625 * 12, 0.0625 * 16, 0.0625 * 12);
+	// SYNC: Must be kept consistent with thistle textures
+    private static final AxisAlignedBB BOUNDING_BOX_0 = new AxisAlignedBB(0.0625 * 5, 0.0625 * 0, 0.0625 * 5, 0.0625 * 11, 0.0625 * 4, 0.0625 * 11);
+    private static final AxisAlignedBB BOUNDING_BOX_1 = new AxisAlignedBB(0.0625 * 5, 0.0625 * 0, 0.0625 * 5, 0.0625 * 11, 0.0625 * 9, 0.0625 * 11);
+    private static final AxisAlignedBB BOUNDING_BOX_2 = new AxisAlignedBB(0.0625 * 4, 0.0625 * 0, 0.0625 * 4, 0.0625 * 12, 0.0625 * 15, 0.0625 * 12);
+    private static final AxisAlignedBB BOUNDING_BOX_3 = new AxisAlignedBB(0.0625 * 2, 0.0625 * 0, 0.0625 * 2, 0.0625 * 14, 0.0625 * 16, 0.0625 * 14);
 
     public BlockThistle(String unlocalizedName) {
         this.setUnlocalizedName(unlocalizedName);
@@ -49,7 +53,15 @@ public class BlockThistle extends BlockCrops implements IGrowable, IPlantable {
 
     @Override
     public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
-        return BOUNDING_BOX;
+    	// SYNC: Must be kept consistent with thistle.json blockstate configuration
+    	int age = state.getValue(AGE);
+    	if( age <= 2 )
+    		return BOUNDING_BOX_0;
+    	if( age <= 4 )
+    		return BOUNDING_BOX_1;
+    	if( age <= 6 )
+    		return BOUNDING_BOX_2;
+    	return BOUNDING_BOX_3;
     }
 
     @Override

--- a/src/main/resources/assets/growthcraft_milk/blockstates/thistle.json
+++ b/src/main/resources/assets/growthcraft_milk/blockstates/thistle.json
@@ -2,11 +2,11 @@
   "variants": {
     "age=0": { "model": "growthcraft_milk:thistle_stage0" },
     "age=1": { "model": "growthcraft_milk:thistle_stage0" },
-    "age=2": { "model": "growthcraft_milk:thistle_stage1" },
+    "age=2": { "model": "growthcraft_milk:thistle_stage0" },
     "age=3": { "model": "growthcraft_milk:thistle_stage1" },
-    "age=4": { "model": "growthcraft_milk:thistle_stage2" },
+    "age=4": { "model": "growthcraft_milk:thistle_stage1" },
     "age=5": { "model": "growthcraft_milk:thistle_stage2" },
-    "age=6": { "model": "growthcraft_milk:thistle_stage3" },
+    "age=6": { "model": "growthcraft_milk:thistle_stage2" },
     "age=7": { "model": "growthcraft_milk:thistle_stage3" }
   }
 }


### PR DESCRIPTION
Following changes were introduced:
- Thistle bounding box is reactive to age.
- Fixed Thistle texture, so that the stage 3 texture only appears for last age state. Helps with confusion with unripe thistle plant.
- Brewing kettle wall fix.
- Brewing kettle bounding box is reactive to whether the lid is put on top or not.
- Rope bounding box is reactive to connection state, now.
- Fixed step sounds for ropes.