### PR TITLE
Added feets to cheese vat.

### DIFF
--- a/src/main/java/growthcraft/milk/common/block/BlockCheeseVat.java
+++ b/src/main/java/growthcraft/milk/common/block/BlockCheeseVat.java
@@ -3,6 +3,7 @@ package growthcraft.milk.common.block;
 import java.util.List;
 import java.util.Random;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import growthcraft.core.shared.block.GrowthcraftBlockContainer;
@@ -12,6 +13,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -37,7 +39,11 @@ public class BlockCheeseVat extends GrowthcraftBlockContainer {
     // The amount of milk in the Cheese Vat
 
 //    public static final PropertyInteger LEVEL = PropertyInteger.create("level", 0, 5);
-
+	public static final PropertyBool ATTACH_NORTH = PropertyBool.create("attachnorth");
+	public static final PropertyBool ATTACH_SOUTH = PropertyBool.create("attachsouth");
+	public static final PropertyBool ATTACH_EAST = PropertyBool.create("attacheast");
+	public static final PropertyBool ATTACH_WEST = PropertyBool.create("attachwest");
+	
     private static final AxisAlignedBB BOUNDING_BOX = new AxisAlignedBB(
             0.0625 * 1, 0.0625 * 0, 0.0625 * 1,
             0.0625 * 15, 0.0625 * 14, 0.0625 * 15);
@@ -51,6 +57,7 @@ public class BlockCheeseVat extends GrowthcraftBlockContainer {
         this.setSoundType(SoundType.METAL);
         this.useNeighborBrightness = true;
 //        this.setDefaultState(this.blockState.getBaseState().withProperty(LEVEL, Integer.valueOf(0)));
+        this.setDefaultState(this.blockState.getBaseState());
         setTileEntityType(TileEntityCheeseVat.class);
     }
 
@@ -102,23 +109,36 @@ public class BlockCheeseVat extends GrowthcraftBlockContainer {
     public boolean isFullBlock(IBlockState state) {
         return false;
     }
-/*
+	
+	@Nonnull
+	@Override
+	protected BlockStateContainer createBlockState() {
+	    return new BlockStateContainer(this, ATTACH_NORTH, ATTACH_SOUTH, ATTACH_EAST, ATTACH_WEST );
+	}
+	
     @Override
     public IBlockState getStateFromMeta(int meta) {
-        return this.getDefaultState().withProperty(LEVEL, Integer.valueOf(meta));
+        return this.getDefaultState();
     }
 
     @Override
     public int getMetaFromState(IBlockState state) {
-        return state.getValue(LEVEL).intValue();
+        return 0;
     }
+	
+	@Override
+    public IBlockState getActualState(IBlockState state, IBlockAccess worldIn, BlockPos pos)
+    {
+		BlockPos down = pos.down();
+		IBlockState stateDown = worldIn.getBlockState(down);
+		boolean isOpaqueDown = stateDown.isOpaqueCube();
 
-    @Override
-    protected BlockStateContainer createBlockState() {
-        return new BlockStateContainer(this, LEVEL);
+		return state.withProperty(ATTACH_NORTH, !isOpaqueDown && worldIn.getBlockState(down.north()).isOpaqueCube())
+		            .withProperty(ATTACH_SOUTH, !isOpaqueDown && worldIn.getBlockState(down.south()).isOpaqueCube())
+		            .withProperty(ATTACH_EAST, !isOpaqueDown && worldIn.getBlockState(down.east()).isOpaqueCube())
+		            .withProperty(ATTACH_WEST, !isOpaqueDown && worldIn.getBlockState(down.west()).isOpaqueCube());
     }
-*/
-
+	
 	@SuppressWarnings("deprecation")
 	@Override
 	public boolean hasComparatorInputOverride(IBlockState state)

--- a/src/main/resources/assets/growthcraft_milk/blockstates/cheese_vat.json
+++ b/src/main/resources/assets/growthcraft_milk/blockstates/cheese_vat.json
@@ -1,25 +1,40 @@
 {
+  "forge_marker": 1,
+  "defaults": {
+    "model": "growthcraft_milk:cheese_vat_empty"
+  },
   "variants": {
-    "normal": {
-      "model": "growthcraft_milk:cheese_vat_empty"
+    "normal": [{ }],
+    "inventory": [{
+       "y": 0
+    }],
+    "attachnorth" : {
+      "true" : {
+        "submodel" : "growthcraft_milk:cheese_vat_feet_north"
+      },
+      "false" : {
+      }
     },
-    "rotation=north": {
-      "model": "growthcraft_milk:cheese_vat_empty"
+    "attachsouth" : {
+      "true" : {
+        "submodel" : "growthcraft_milk:cheese_vat_feet_south"
+      },
+      "false" : {
+      }
     },
-    "rotation=south": {
-      "model": "growthcraft_milk:cheese_vat_empty"
+    "attacheast" : {
+      "true" : {
+        "submodel" : "growthcraft_milk:cheese_vat_feet_east"
+      },
+      "false" : {
+      }
     },
-    "rotation=east": {
-      "model": "growthcraft_milk:cheese_vat_empty"
-    },
-    "rotation=west": {
-      "model": "growthcraft_milk:cheese_vat_empty"
-    },
-    "rotation=up": {
-      "model": "growthcraft_milk:cheese_vat_empty"
-    },
-    "rotation=down": {
-      "model": "growthcraft_milk:cheese_vat_empty"
+    "attachwest" : {
+      "true" : {
+        "submodel" : "growthcraft_milk:cheese_vat_feet_west"
+      },
+      "false" : {
+      }
     }
   }
 }

--- a/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_east.json
+++ b/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_east.json
@@ -1,0 +1,79 @@
+{
+	"credit": "Made with Blockbench, a free, modern block model editor by JannisX11",
+	"textures": {
+		"0": "growthcraft_milk:blocks/cheese_vat",
+		"particle": "growthcraft_milk:blocks/cheese_vat"
+	},
+	"elements": [
+		{
+			"name": "cube",
+			"from": [15, 0, 7],
+			"to": [17, 1, 9],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"up": {"uv": [0, 0, 2, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#0"}
+			},
+			"type": "cube"
+		},
+		{
+			"name": "cube",
+			"from": [15, -1, 7],
+			"to": [16, 0, 9],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 1, 1],
+					"texture": "#0"
+				},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {
+					"uv": [0, 0, 1, 1],
+					"texture": "#0"
+				},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 2], "texture": "#0"}
+			},
+			"type": "cube"
+		}
+	],
+	"display": {
+		"gui": {
+			"rotation": [30, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.625, 0.625, 0.625]
+		},
+		"ground": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 3, 0],
+			"scale": [0.25, 0.25, 0.25]
+		},
+		"fixed": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"thirdperson_righthand": {
+			"rotation": [75, 45, 0],
+			"translation": [0, 2.5, 0],
+			"scale": [0.375, 0.375, 0.375]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 45, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		}
+	}
+}

--- a/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_north.json
+++ b/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_north.json
@@ -1,0 +1,76 @@
+{
+	"credit": "Made with Blockbench, a free, modern block model editor by JannisX11",
+	"textures": {
+		"0": "growthcraft_milk:blocks/cheese_vat",
+		"particle": "growthcraft_milk:blocks/cheese_vat"
+	},
+	"elements": [
+		{
+			"name": "cube",
+			"from": [7, 0, -1],
+			"to": [9, 1, 1],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 2, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#0"}
+			},
+			"type": "cube"
+		},
+		{
+			"name": "cube",
+			"from": [7, -1, 0],
+			"to": [9, 0, 1],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 1], "texture": "#0"}
+			},
+			"type": "cube"
+		}
+	],
+	"display": {
+		"gui": {
+			"rotation": [30, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.625, 0.625, 0.625]
+		},
+		"ground": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 3, 0],
+			"scale": [0.25, 0.25, 0.25]
+		},
+		"fixed": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"thirdperson_righthand": {
+			"rotation": [75, 45, 0],
+			"translation": [0, 2.5, 0],
+			"scale": [0.375, 0.375, 0.375]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 45, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		}
+	}
+}

--- a/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_south.json
+++ b/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_south.json
@@ -1,0 +1,76 @@
+{
+	"credit": "Made with Blockbench, a free, modern block model editor by JannisX11",
+	"textures": {
+		"0": "growthcraft_milk:blocks/cheese_vat",
+		"particle": "growthcraft_milk:blocks/cheese_vat"
+	},
+	"elements": [
+		{
+			"name": "cube",
+			"from": [7, 0, 15],
+			"to": [9, 1, 17],
+			"faces": {
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 2, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#0"}
+			},
+			"type": "cube"
+		},
+		{
+			"name": "cube",
+			"from": [7, -1, 15],
+			"to": [9, 0, 16],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"east": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"south": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"west": {"uv": [0, 0, 1, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 1], "texture": "#0"}
+			},
+			"type": "cube"
+		}
+	],
+	"display": {
+		"gui": {
+			"rotation": [30, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.625, 0.625, 0.625]
+		},
+		"ground": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 3, 0],
+			"scale": [0.25, 0.25, 0.25]
+		},
+		"fixed": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"thirdperson_righthand": {
+			"rotation": [75, 45, 0],
+			"translation": [0, 2.5, 0],
+			"scale": [0.375, 0.375, 0.375]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 45, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		}
+	}
+}

--- a/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_west.json
+++ b/src/main/resources/assets/growthcraft_milk/models/block/cheese_vat_feet_west.json
@@ -1,0 +1,79 @@
+{
+	"credit": "Made with Blockbench, a free, modern block model editor by JannisX11",
+	"textures": {
+		"0": "growthcraft_milk:blocks/cheese_vat",
+		"particle": "growthcraft_milk:blocks/cheese_vat"
+	},
+	"elements": [
+		{
+			"name": "cube",
+			"from": [-1, 0, 7],
+			"to": [1, 1, 9],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"south": {
+					"uv": [0, 0, 2, 1],
+					"texture": "#0"
+				},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"up": {"uv": [0, 0, 2, 2], "texture": "#0"},
+				"down": {"uv": [0, 0, 2, 2], "texture": "#0"}
+			},
+			"type": "cube"
+		},
+		{
+			"name": "cube",
+			"from": [0, -1, 7],
+			"to": [1, 0, 9],
+			"faces": {
+				"north": {
+					"uv": [0, 0, 1, 1],
+					"texture": "#0"
+				},
+				"east": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"south": {
+					"uv": [0, 0, 1, 1],
+					"texture": "#0"
+				},
+				"west": {"uv": [0, 0, 2, 1], "texture": "#0"},
+				"down": {"uv": [0, 0, 1, 2], "texture": "#0"}
+			},
+			"type": "cube"
+		}
+	],
+	"display": {
+		"gui": {
+			"rotation": [30, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.625, 0.625, 0.625]
+		},
+		"ground": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 3, 0],
+			"scale": [0.25, 0.25, 0.25]
+		},
+		"fixed": {
+			"rotation": [0, 0, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.5, 0.5, 0.5]
+		},
+		"thirdperson_righthand": {
+			"rotation": [75, 45, 0],
+			"translation": [0, 2.5, 0],
+			"scale": [0.375, 0.375, 0.375]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 45, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 225, 0],
+			"translation": [0, 0, 0],
+			"scale": [0.4, 0.4, 0.4]
+		}
+	}
+}


### PR DESCRIPTION
Added feets for cheese vat if floating above air or fire. This feature was originally suggested for GC for MC  .1.11.2

![grafik](https://user-images.githubusercontent.com/21110130/51391295-fb00ec80-1b31-11e9-8486-b8886d94ed1b.png)

Feets are responsive also to neighbor blocks:
![grafik](https://user-images.githubusercontent.com/21110130/51391380-33082f80-1b32-11e9-8fce-86aab88f502e.png)
