### PR TITLE
Refactoring for devices and processes

### DIFF
--- a/src/main/java/growthcraft/cellar/common/compat/waila/WailaDataProvider.java
+++ b/src/main/java/growthcraft/cellar/common/compat/waila/WailaDataProvider.java
@@ -28,7 +28,7 @@ public class WailaDataProvider implements IWailaDataProvider {
         // TODO: Sync TileEntity server object with client when getDeviceProgressScaled is called client side. Otherwise client has to opne the GUI to get an update.
         if(tileEntity instanceof ITileProgressiveDevice){
             float progress = ((ITileProgressiveDevice) tileEntity).getDeviceProgressScaled(100);
-            if(progress >= 0){
+            if(progress > 0){
                 tooltip.add(TextFormatting.GREEN + "Progress: " + progress + "%");
             }
         }

--- a/src/main/java/growthcraft/cellar/common/compat/waila/WailaDataProvider.java
+++ b/src/main/java/growthcraft/cellar/common/compat/waila/WailaDataProvider.java
@@ -1,7 +1,8 @@
 package growthcraft.cellar.common.compat.waila;
 
-import growthcraft.cellar.common.block.BlockFermentBarrel;
 import growthcraft.cellar.common.tileentity.TileEntityFermentBarrel;
+import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
+import growthcraft.core.shared.tileentity.feature.ITileProgressiveDevice;
 import mcp.mobius.waila.api.IWailaConfigHandler;
 import mcp.mobius.waila.api.IWailaDataAccessor;
 import mcp.mobius.waila.api.IWailaDataProvider;
@@ -17,23 +18,27 @@ import java.util.List;
 public class WailaDataProvider implements IWailaDataProvider {
 
     public static void callbackRegister(IWailaRegistrar registrar) {
-        registrar.registerBodyProvider(new WailaDataProvider(), BlockFermentBarrel.class);
+        registrar.registerBodyProvider(new WailaDataProvider(), GrowthcraftTileDeviceBase.class);
     }
 
     @Nonnull
     @Override
     public List<String> getWailaBody(ItemStack itemStack, List<String> tooltip, IWailaDataAccessor accessor, IWailaConfigHandler config) {
         final TileEntity tileEntity = accessor.getTileEntity();
+        // TODO: Sync TileEntity server object with client when getDeviceProgressScaled is called client side. Otherwise client has to opne the GUI to get an update.
+        if(tileEntity instanceof ITileProgressiveDevice){
+            float progress = ((ITileProgressiveDevice) tileEntity).getDeviceProgressScaled(100);
+            if(progress >= 0){
+                tooltip.add(TextFormatting.GREEN + "Progress: " + progress + "%");
+            }
+        }
 
         if (tileEntity instanceof TileEntityFermentBarrel) {
             // TODO: Sync TileEntityFermentBarrel server object with client. Otherwise client has to opne the GUI to get an update.
-
-            float progress = ((TileEntityFermentBarrel) tileEntity).getDeviceProgressScaled(100);
             FluidTank fluidTank = ((TileEntityFermentBarrel) tileEntity).getFluidTank(0);
 
             if (fluidTank.getFluidAmount() > 0) {
                 tooltip.add(TextFormatting.GREEN + String.format("%dmb %s", fluidTank.getFluidAmount(), fluidTank.getFluid().getLocalizedName()));
-                tooltip.add(TextFormatting.GREEN + "Progress: " + progress + "%");
             } else {
                 tooltip.add("Empty");
             }

--- a/src/main/java/growthcraft/cellar/common/tileentity/TileEntityBrewKettle.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/TileEntityBrewKettle.java
@@ -98,6 +98,7 @@ public class TileEntityBrewKettle extends TileEntityCellarDevice implements ITic
         // Brew Kettles need to update their rendering state when a fluid
         // changes, most of the other cellar blocks are unaffected by this
         markForUpdate(true);
+        super.markFluidDirty();
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/common/tileentity/TileEntityBrewKettle.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/TileEntityBrewKettle.java
@@ -14,6 +14,7 @@ import growthcraft.cellar.common.tileentity.fluids.CellarTank;
 import growthcraft.core.shared.client.utils.FXHelper;
 import growthcraft.core.shared.inventory.GrowthcraftInternalInventory;
 import growthcraft.core.shared.item.ItemUtils;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.IItemOperable;
@@ -74,6 +75,9 @@ public class TileEntityBrewKettle extends TileEntityCellarDevice implements ITic
     private SpatialRandom sprand = new SpatialRandom();
     // Crash: @SideOnly(Side.CLIENT)
     private boolean animLastLid = false;    // NOTE: Only use it inside update() on the client side.
+
+    @Override
+    public DeviceBase[] getDevices(){return new DeviceBase[]{brewKettle };}
 
     @Override
     protected FluidTank[] createTanks() {
@@ -190,7 +194,7 @@ public class TileEntityBrewKettle extends TileEntityCellarDevice implements ITic
     }
 
     public boolean canBrew() {
-        return brewKettle.canBrew();
+        return brewKettle.canProcess();
     }
 
     public boolean hasFluid() {

--- a/src/main/java/growthcraft/cellar/common/tileentity/TileEntityCultureJar.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/TileEntityCultureJar.java
@@ -9,6 +9,7 @@ import growthcraft.cellar.common.tileentity.device.CultureGenerator;
 import growthcraft.cellar.common.tileentity.device.YeastGenerator;
 import growthcraft.cellar.common.tileentity.fluids.CellarTank;
 import growthcraft.core.shared.inventory.GrowthcraftInternalInventory;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceProgressive;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.ITileHeatedDevice;
@@ -65,6 +66,9 @@ public class TileEntityCultureJar extends TileEntityCellarDevice implements ITic
         this.yeastGen.setConsumption(GrowthcraftCellarConfig.cultureJarConsumption);
     }
 
+    @Override
+    public DeviceBase[] getDevices(){return new DeviceBase[]{cultureGen,yeastGen};}
+
     public boolean isHeated() {
         return cultureGen.isHeated();
     }
@@ -119,6 +123,7 @@ public class TileEntityCultureJar extends TileEntityCellarDevice implements ITic
 
     @Override
     protected void markFluidDirty() {
+        super.markFluidDirty();
         // Ferment Jars need to update their rendering state when a fluid
         // changes, most of the other cellar blocks are unaffected by this
         markForUpdate(true);
@@ -205,9 +210,9 @@ public class TileEntityCultureJar extends TileEntityCellarDevice implements ITic
     @Override
     public void sendGUINetworkData(Container container, IContainerListener iCrafting) {
         super.sendGUINetworkData(container, iCrafting);
-        iCrafting.sendWindowProperty(container, CultureJarDataId.YEAST_GEN_TIME.ordinal(), yeastGen.getTime());
+        iCrafting.sendWindowProperty(container, CultureJarDataId.YEAST_GEN_TIME.ordinal(), (int)yeastGen.getTime());
         iCrafting.sendWindowProperty(container, CultureJarDataId.YEAST_GEN_TIME_MAX.ordinal(), yeastGen.getTimeMax());
-        iCrafting.sendWindowProperty(container, CultureJarDataId.CULTURE_GEN_TIME.ordinal(), cultureGen.getTime());
+        iCrafting.sendWindowProperty(container, CultureJarDataId.CULTURE_GEN_TIME.ordinal(), (int)cultureGen.getTime());
         iCrafting.sendWindowProperty(container, CultureJarDataId.CULTURE_GEN_TIME_MAX.ordinal(), cultureGen.getTimeMax());
         iCrafting.sendWindowProperty(container, CultureJarDataId.HEAT_AMOUNT.ordinal(), (int) (heatComponent.getHeatMultiplier() * 0x7FFF));
     }

--- a/src/main/java/growthcraft/cellar/common/tileentity/TileEntityFermentBarrel.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/TileEntityFermentBarrel.java
@@ -9,6 +9,7 @@ import growthcraft.core.shared.fluids.FluidTest;
 import growthcraft.core.shared.inventory.GrowthcraftInternalInventory;
 import growthcraft.core.shared.inventory.InventoryProcessor;
 import growthcraft.core.shared.io.nbt.INBTItemSerializable;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.ITileProgressiveDevice;
 import io.netty.buffer.ByteBuf;
@@ -26,6 +27,8 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TileEntityFermentBarrel extends TileEntityCellarDevice implements IInventory, ITickable, ITileProgressiveDevice, INBTItemSerializable {
 
@@ -53,6 +56,9 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
     private final FermentBarrel fermentBarrel = new FermentBarrel(this, 0, 1, 0);
 
     @Override
+    public DeviceBase[] getDevices(){return new DeviceBase[]{fermentBarrel};}
+
+    @Override
     protected FluidTank[] createTanks() {
         return new FluidTank[]{new CellarTank(GrowthcraftCellarConfig.fermentBarrelMaxCap, this)};
     }
@@ -78,7 +84,7 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
     }
 
     public int getTime() {
-        return fermentBarrel.getTime();
+        return (int)fermentBarrel.getTime();
     }
 
     public int getTimeMax() {
@@ -172,7 +178,7 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
     @Override
     public void sendGUINetworkData(Container container, IContainerListener iCrafting) {
         super.sendGUINetworkData(container, iCrafting);
-        iCrafting.sendWindowProperty(container, FermentBarrelDataID.TIME.ordinal(), fermentBarrel.getTime());
+        iCrafting.sendWindowProperty(container, FermentBarrelDataID.TIME.ordinal(), (int)fermentBarrel.getTime());
         iCrafting.sendWindowProperty(container, FermentBarrelDataID.TIME_MAX.ordinal(), fermentBarrel.getTimeMax());    // Not fermentBarrel.getTimeMaxDefault() !
     }
 
@@ -223,13 +229,11 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
     @Override
     protected void markFluidDirty() {
         super.markFluidDirty();
-        fermentBarrel.markForRecipeRecheck();
     }
 
     @Override
     public void onInventoryChanged(IInventory inv, int index) {
         super.onInventoryChanged(inv, index);
-        fermentBarrel.markForRecipeRecheck();
         if (index == 1) {
             // Changing tap has a visual feedback
             this.markDirtyAndUpdate(true);

--- a/src/main/java/growthcraft/cellar/common/tileentity/TileEntityFruitPress.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/TileEntityFruitPress.java
@@ -1,5 +1,6 @@
 package growthcraft.cellar.common.tileentity;
 
+import growthcraft.cellar.common.block.BlockFruitPresser;
 import growthcraft.cellar.shared.config.GrowthcraftCellarConfig;
 import growthcraft.cellar.common.inventory.ContainerFruitPress;
 import growthcraft.cellar.common.tileentity.device.FruitPress;
@@ -88,8 +89,12 @@ public class TileEntityFruitPress extends TileEntityCellarDevice implements ITic
         return allSlotIds;
     }
 
+    public boolean isPressed(){
+        return getWorld().getBlockState(this.getPos().up()).getValue(BlockFruitPresser.TYPE_PRESSED) == BlockFruitPresser.PressState.PRESSED;
+    }
     @Override
     public boolean canInsertItem(int index, ItemStack stack, EnumFacing side) {
+        if(isPressed()) return false;
         // allow the insertion of a raw item from ANY side
         if (index == 0) return true;
         return false;

--- a/src/main/java/growthcraft/cellar/common/tileentity/TileEntityFruitPress.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/TileEntityFruitPress.java
@@ -5,6 +5,7 @@ import growthcraft.cellar.common.inventory.ContainerFruitPress;
 import growthcraft.cellar.common.tileentity.device.FruitPress;
 import growthcraft.cellar.common.tileentity.fluids.CellarTank;
 import growthcraft.core.shared.inventory.GrowthcraftInternalInventory;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.ITileProgressiveDevice;
 import net.minecraft.entity.player.EntityPlayer;
@@ -33,6 +34,9 @@ public class TileEntityFruitPress extends TileEntityCellarDevice implements ITic
     private static final int[] allSlotIds = new int[]{0, 1};
     private static final int[] residueSlotIds = new int[]{0};
     private FruitPress fruitPress = new FruitPress(this, 0, 0, 1);
+
+    @Override
+    public DeviceBase[] getDevices(){return new DeviceBase[]{fruitPress};}
 
     @Override
     protected FluidTank[] createTanks() {
@@ -170,7 +174,7 @@ public class TileEntityFruitPress extends TileEntityCellarDevice implements ITic
     @Override
     public void sendGUINetworkData(Container container, IContainerListener iCrafting) {
         super.sendGUINetworkData(container, iCrafting);
-        iCrafting.sendWindowProperty(container, FruitPressDataID.TIME, fruitPress.getTime());
+        iCrafting.sendWindowProperty(container, FruitPressDataID.TIME, (int)fruitPress.getTime());
         iCrafting.sendWindowProperty(container, FruitPressDataID.TIME_MAX, fruitPress.getTimeMax());
     }
 

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/BrewKettle.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/BrewKettle.java
@@ -12,17 +12,16 @@ import growthcraft.core.shared.fluids.GrowthcraftFluidUtils;
 import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
+import growthcraft.core.shared.tileentity.device.DeviceProgressive;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.FluidStack;
 
-public class BrewKettle extends DeviceBase {
+public class BrewKettle extends DeviceProgressive<IBrewingRecipe> {
     // TODO: Create same recipe caching mechanism as for barrels. Is more performant, if recipe check is avoided on each TileEntity update.
 
     private float grain;
-    private double time;
-    private double timeMax;
     private DeviceInventorySlot brewingSlot;
     private DeviceInventorySlot residueSlot;
     private DeviceInventorySlot lidSlot;
@@ -44,38 +43,6 @@ public class BrewKettle extends DeviceBase {
         this.grain = g;
     }
 
-    public double getTime() {
-        return time;
-    }
-
-    public void setTime(double t) {
-        this.time = t;
-    }
-
-    public double getTimeMax() {
-        return timeMax;
-    }
-
-    public void setTimeMax(double t) {
-        this.timeMax = t;
-    }
-
-    public boolean resetTime() {
-        if (time != 0) {
-            setTime(0);
-            return true;
-        }
-        return false;
-    }
-
-    public float getProgress() {
-        if (timeMax == 0) return 0f;
-        return (float) (time / timeMax);
-    }
-
-    public int getProgressScaled(int scale) {
-        return (int) (getProgress() * scale);
-    }
 
     public BrewKettle setHeatMultiplier(float h) {
         heatComponent.setHeatMultiplier(h);
@@ -94,15 +61,17 @@ public class BrewKettle extends DeviceBase {
         return inputFluidSlot.hasContent() || outputFluidSlot.hasContent();
     }
 
-    private IBrewingRecipe findRecipe() {
+    @Override
+    protected IBrewingRecipe loadRecipe() {
         boolean hasLid = GrowthcraftCellarItems.brewKettleLid.equals(lidSlot.get().getItem());
         return CellarRegistry.instance().brewing().findRecipe(GrowthcraftFluidUtils.removeStackTags(inputFluidSlot.get()), brewingSlot.get(), hasLid);
     }
 
+    @Override
     public IBrewingRecipe getWorkingRecipe() {
         if (!isHeated()) return null;
 
-        final IBrewingRecipe recipe = findRecipe();
+        final IBrewingRecipe recipe = loadRecipe();
         if (recipe == null) return null;
 
         if (brewingSlot.isEmpty()) return null;
@@ -121,10 +90,11 @@ public class BrewKettle extends DeviceBase {
         final FluidStack outputFluid = recipe.asFluidStack();
         if (!outputFluidSlot.hasCapacityFor(outputFluid)) return null;
 
-        return recipe;
+        return super.getWorkingRecipe();
     }
 
-    public boolean canBrew() {
+    @Override
+    public boolean canProcess() {
         return getWorkingRecipe() != null;
     }
 
@@ -139,7 +109,8 @@ public class BrewKettle extends DeviceBase {
         }
     }
 
-    private void brewItem(IBrewingRecipe recipe) {
+    protected void process(IBrewingRecipe recipe) {
+        if(!canProcess()) return;
         produceGrain(recipe);
         inputFluidSlot.consume(GrowthcraftFluidUtils.replaceFluidStackTags(recipe.getInputFluidStack(), inputFluidSlot.get()), true);
         outputFluidSlot.fill(recipe.asFluidStack(), true);
@@ -152,28 +123,19 @@ public class BrewKettle extends DeviceBase {
         MinecraftForge.EVENT_BUS.post(new EventBrewed(parent, recipe));
     }
 
+    @Override
+    protected float getSpeedMultiplier(){
+        return super.getSpeedMultiplier()*getHeatMultiplier();
+    }
+
     public void update() {
         heatComponent.update();
-        final IBrewingRecipe recipe = getWorkingRecipe();
-        if (recipe != null) {
-            this.timeMax = (double) recipe.getTime();
-
-            final float multiplier = getHeatMultiplier();
-            this.time += multiplier * 1;
-
-            if (time >= timeMax) {
-                resetTime();
-                brewItem(recipe);
-            }
-        } else {
-            if (resetTime()) markForUpdate(true);
-        }
+        super.update();
     }
 
     @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
-        this.time = data.getDouble("time");
         this.grain = data.getFloat("grain");
         heatComponent.readFromNBT(data, "heat_component");
     }
@@ -181,7 +143,6 @@ public class BrewKettle extends DeviceBase {
     @Override
     public void writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
-        data.setDouble("time", time);
         data.setFloat("grain", grain);
         heatComponent.writeToNBT(data, "heat_component");
     }
@@ -192,8 +153,6 @@ public class BrewKettle extends DeviceBase {
     @Override
     public boolean readFromStream(ByteBuf buf) {
         super.readFromStream(buf);
-        this.time = buf.readDouble();
-        this.timeMax = buf.readDouble();
         this.grain = buf.readFloat();
         heatComponent.readFromStream(buf);
         return false;
@@ -205,8 +164,6 @@ public class BrewKettle extends DeviceBase {
     @Override
     public boolean writeToStream(ByteBuf buf) {
         super.writeToStream(buf);
-        buf.writeDouble(time);
-        buf.writeDouble(timeMax);
         buf.writeFloat(grain);
         heatComponent.writeToStream(buf);
         return false;

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/CultureGenerator.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/CultureGenerator.java
@@ -1,6 +1,7 @@
 package growthcraft.cellar.common.tileentity.device;
 
 import growthcraft.cellar.shared.CellarRegistry;
+import growthcraft.cellar.shared.processing.brewing.IBrewingRecipe;
 import growthcraft.cellar.shared.processing.culturing.ICultureRecipe;
 import growthcraft.cellar.common.tileentity.TileEntityCellarDevice;
 import growthcraft.cellar.shared.processing.fermenting.IFermentationRecipe;
@@ -46,9 +47,12 @@ public class CultureGenerator extends DeviceProgressive<ICultureRecipe> {
     protected boolean canProcess() {
         ICultureRecipe recipe = getWorkingRecipe();
         if(recipe == null) return false;
-        if(!fluidSlot.hasContent()) return false;
-        if (!fluidSlot.hasEnough(recipe.getInputFluidStack())) return false;
-        return invSlot.isEmpty() || invSlot.hasMatchingWithCapacity(recipe.getOutputItemStack());
+        //Checks for input fluids
+        if(!fluidSlot.hasEnough(recipe.getInputFluidStack())) return false;
+        //Checks for output items
+        if(!invSlot.hasCapacityFor(recipe.getOutputItemStack())) return false;
+
+        return true;
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/CultureGenerator.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/CultureGenerator.java
@@ -3,12 +3,14 @@ package growthcraft.cellar.common.tileentity.device;
 import growthcraft.cellar.shared.CellarRegistry;
 import growthcraft.cellar.shared.processing.culturing.ICultureRecipe;
 import growthcraft.cellar.common.tileentity.TileEntityCellarDevice;
+import growthcraft.cellar.shared.processing.fermenting.IFermentationRecipe;
+import growthcraft.core.shared.fluids.GrowthcraftFluidUtils;
 import growthcraft.core.shared.tileentity.component.TileHeatingComponent;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.device.DeviceProgressive;
 
-public class CultureGenerator extends DeviceProgressive {
+public class CultureGenerator extends DeviceProgressive<ICultureRecipe> {
     protected DeviceFluidSlot fluidSlot;
     protected DeviceInventorySlot invSlot;
     protected TileHeatingComponent heatComponent;
@@ -28,47 +30,36 @@ public class CultureGenerator extends DeviceProgressive {
         setTimeMax(1200);
     }
 
-    public float getHeatMultiplier() {
-        return heatComponent.getHeatMultiplier();
+    @Override
+    protected ICultureRecipe loadRecipe() {
+        return  CellarRegistry.instance().culturing().findRecipe(fluidSlot.get(), heatComponent.getHeatMultiplier());
     }
 
-    @Override
-    public void increaseTime() {
-        this.time += 1;
+    public float getHeatMultiplier() {
+        return heatComponent.getHeatMultiplier();
     }
 
     public boolean isHeated() {
         return heatComponent.isHeated();
     }
 
-    private boolean isRecipeValid(ICultureRecipe recipe) {
-        if (recipe != null) {
-            if (fluidSlot.hasEnough(recipe.getInputFluidStack())) {
-                return invSlot.isEmpty() || invSlot.hasMatchingWithCapacity(recipe.getOutputItemStack());
-            }
-        }
-        return false;
+    protected boolean canProcess() {
+        ICultureRecipe recipe = getWorkingRecipe();
+        if(recipe == null) return false;
+        if(!fluidSlot.hasContent()) return false;
+        if (!fluidSlot.hasEnough(recipe.getInputFluidStack())) return false;
+        return invSlot.isEmpty() || invSlot.hasMatchingWithCapacity(recipe.getOutputItemStack());
     }
 
-    private void produceCulture(ICultureRecipe recipe) {
+    @Override
+    protected void process(ICultureRecipe recipe) {
+        if(! canProcess()){return;}
         fluidSlot.consume(recipe.getInputFluidStack(), true);
         invSlot.increaseStack(recipe.getOutputItemStack());
     }
 
     @Override
     public void update() {
-        final ICultureRecipe activeRecipe = CellarRegistry.instance().culturing().findRecipe(fluidSlot.get(), heatComponent.getHeatMultiplier());
-
-        if (isRecipeValid(activeRecipe)) {
-            setTimeMax(activeRecipe.getTime());
-            increaseTime();
-            if (time >= timeMax) {
-                resetTime();
-                produceCulture(activeRecipe);
-                markDirty();
-            }
-        } else {
-            if (resetTime()) markDirty();
-        }
+        super.update();
     }
 }

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/FermentBarrel.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/FermentBarrel.java
@@ -8,11 +8,9 @@ import growthcraft.core.shared.definition.IMultiItemStacks;
 import growthcraft.core.shared.fluids.GrowthcraftFluidUtils;
 import growthcraft.core.shared.io.nbt.NBTHelper;
 import growthcraft.core.shared.item.ItemUtils;
-import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.device.DeviceProgressive;
-import io.netty.buffer.ByteBuf;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
@@ -20,14 +18,12 @@ import net.minecraftforge.fluids.FluidStack;
 public class FermentBarrel extends DeviceProgressive<IFermentationRecipe> {
 
     private DeviceInventorySlot fermentSlot;
-    private DeviceInventorySlot tapSlot;
     private DeviceFluidSlot fluidSlot;
 
     public FermentBarrel(TileEntityFermentBarrel te, int fermentSlotId, int tapSlotId, int fluidSlotId) {
         super(te);
         this.timeMax = GrowthcraftCellarConfig.fermentTime;
         this.fermentSlot = new DeviceInventorySlot(te, fermentSlotId);
-        this.tapSlot = new DeviceInventorySlot(te, tapSlotId);
         this.fluidSlot = new DeviceFluidSlot(te, fluidSlotId);
     }
 
@@ -39,9 +35,14 @@ public class FermentBarrel extends DeviceProgressive<IFermentationRecipe> {
 
 
     protected boolean canProcess() {
-        if (ItemUtils.isEmpty(fermentSlot.get())) return false;
-        if (fluidSlot.isEmpty()) return false;
-        return getWorkingRecipe() != null;
+        IFermentationRecipe recipe = getWorkingRecipe();
+        if(recipe == null) return false;
+        //Checks for input fluids
+        if(!recipe.getInputFluidStack().containsFluidStack(fluidSlot.get())) return false;
+        //Checks for input items
+        if(!recipe.getFermentingItemStack().containsItemStack(fermentSlot.get())) return false;
+
+        return true;
     }
 
     @Override
@@ -66,10 +67,6 @@ public class FermentBarrel extends DeviceProgressive<IFermentationRecipe> {
         }
     }
 
-    @Override
-    public void update() {
-        super.update();
-    }
 
     // I/O Stuff
 

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/FermentBarrel.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/FermentBarrel.java
@@ -11,19 +11,13 @@ import growthcraft.core.shared.item.ItemUtils;
 import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
+import growthcraft.core.shared.tileentity.device.DeviceProgressive;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
 
-public class FermentBarrel extends DeviceBase {
-
-    private int timemax = GrowthcraftCellarConfig.fermentTime;
-    private boolean shouldUseCachedRecipe = GrowthcraftCellarConfig.fermentBarrelUseCachedRecipe;
-
-    protected int time;
-    private boolean recheckRecipe = true;
-    private IFermentationRecipe activeRecipe;
+public class FermentBarrel extends DeviceProgressive<IFermentationRecipe> {
 
     private DeviceInventorySlot fermentSlot;
     private DeviceInventorySlot tapSlot;
@@ -31,82 +25,29 @@ public class FermentBarrel extends DeviceBase {
 
     public FermentBarrel(TileEntityFermentBarrel te, int fermentSlotId, int tapSlotId, int fluidSlotId) {
         super(te);
+        this.timeMax = GrowthcraftCellarConfig.fermentTime;
         this.fermentSlot = new DeviceInventorySlot(te, fermentSlotId);
         this.tapSlot = new DeviceInventorySlot(te, tapSlotId);
         this.fluidSlot = new DeviceFluidSlot(te, fluidSlotId);
     }
 
-    public void markForRecipeRecheck() {
-        this.recheckRecipe = true;
-    }
 
-    /**
-     * @return time was reset, false otherwise
-     */
-    protected boolean resetTime() {
-        if (time != 0) {
-            this.time = 0;
-            return true;
-        }
-        return false;
-    }
-
-    private IFermentationRecipe loadRecipe() {
+    @Override
+    protected IFermentationRecipe loadRecipe() {
         return CellarRegistry.instance().fermenting().findRecipe(GrowthcraftFluidUtils.removeStackTags(fluidSlot.get()), fermentSlot.get());
     }
 
-    private IFermentationRecipe refreshRecipe() {
-        final IFermentationRecipe recipe = loadRecipe();
-        if (recipe != null && recipe != activeRecipe) {
-            if (activeRecipe != null) {
-                resetTime();
-            }
-            this.activeRecipe = recipe;
-            markDirty();
-        } else {
-            if (activeRecipe != null) {
-                this.activeRecipe = null;
-                resetTime();
-                markDirty();
-            }
-        }
-        return activeRecipe;
-    }
 
-    private IFermentationRecipe getWorkingRecipe() {
-        if (shouldUseCachedRecipe) {
-            if (activeRecipe == null) refreshRecipe();
-            return activeRecipe;
-        }
-        return loadRecipe();
-    }
-
-    public void setTime(int time) {
-        this.time = time;
-    }
-
-    public int getTime() {
-        return this.time;
-    }
-
-    public int getTimeMax() {
-        return this.timemax;
-    }
-
-    public void setTimeMax(int timeMax) {
-        this.timemax = timeMax;
-    }
-
-    private boolean canFerment() {
+    protected boolean canProcess() {
         if (ItemUtils.isEmpty(fermentSlot.get())) return false;
         if (fluidSlot.isEmpty()) return false;
         return getWorkingRecipe() != null;
     }
 
-    public void fermentItem() {
+    @Override
+    public void process(IFermentationRecipe recipe) {
         final ItemStack fermentItem = fermentSlot.get();
         if (!ItemUtils.isEmpty(fermentItem)) {
-            final IFermentationRecipe recipe = getWorkingRecipe();
             if (recipe != null) {
                 final FluidStack outputFluidStack = recipe.getOutputFluidStack();
                 if (outputFluidStack != null) {
@@ -125,47 +66,9 @@ public class FermentBarrel extends DeviceBase {
         }
     }
 
-    public float getProgress() {
-        final int tmx = getTimeMax();
-        if (tmx > 0) {
-            return (float) time / (float) tmx;
-        }
-        return 0.0f;
-    }
-
-    public int getProgressScaled(int scale) {
-        final int tmx = getTimeMax();
-        if (tmx > 0) {
-            return this.time * scale / tmx;
-        }
-        return 0;
-    }
-
+    @Override
     public void update() {
-        if (recheckRecipe) {
-            this.recheckRecipe = false;
-            refreshRecipe();
-        }
-
-        final IFermentationRecipe recipe = getWorkingRecipe();
-        if (recipe != null)
-            this.timemax = recipe.getTime();
-
-        if (canFerment()) {
-            this.time++;
-
-            if (time >= getTimeMax()) {
-                resetTime();
-                fermentItem();
-            }
-            markDirtyAndUpdate(false);
-        } else {
-            if (time != 0) {
-                resetTime();
-                markDirtyAndUpdate(false);
-            }
-        }
-
+        super.update();
     }
 
     // I/O Stuff
@@ -179,27 +82,5 @@ public class FermentBarrel extends DeviceBase {
         // NOTE: Initialize newer fields here if any!
     }
 
-    @Override
-    public void readFromNBT(NBTTagCompound data) {
-        this.time = NBTHelper.getInteger(data, "time");
-    }
-
-    @Override
-    public void writeToNBT(NBTTagCompound data) {
-        data.setInteger("time", this.time);
-    }
-
-    @Override
-    public boolean readFromStream(ByteBuf buf) {
-        this.time = buf.readInt();
-        this.timemax = buf.readInt();
-        return false;
-    }
-
-    public boolean writeToStream(ByteBuf buf) {
-        buf.writeInt(this.time);
-        buf.writeInt(this.timemax);    // Change of logic! Not using getTimeMax()
-        return false;
-    }
 
 }

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/FruitPress.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/FruitPress.java
@@ -2,6 +2,7 @@ package growthcraft.cellar.common.tileentity.device;
 
 import growthcraft.cellar.common.block.BlockFruitPresser;
 import growthcraft.cellar.common.block.BlockFruitPresser.PressState;
+import growthcraft.cellar.common.tileentity.TileEntityFruitPress;
 import growthcraft.cellar.shared.CellarRegistry;
 import growthcraft.cellar.shared.processing.common.Residue;
 import growthcraft.cellar.shared.processing.pressing.IPressingRecipe;
@@ -34,11 +35,12 @@ public class FruitPress extends DeviceProgressive<IPressingRecipe> {
         this.residueSlot = new DeviceInventorySlot(te, rs);
     }
 
-    /**
-     * @return meta - the metadata for the FruitPresser usually above the fruit press
-     */
+
     public boolean isPressed() {
-        return getWorld().getBlockState(parent.getPos().up()).getValue(BlockFruitPresser.TYPE_PRESSED) == PressState.PRESSED;
+       if(parent instanceof TileEntityFruitPress){
+           return ((TileEntityFruitPress)parent).isPressed();
+       }
+        return false;
     }
 
     @Override

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/FruitPress.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/FruitPress.java
@@ -4,10 +4,8 @@ import growthcraft.cellar.common.block.BlockFruitPresser;
 import growthcraft.cellar.common.block.BlockFruitPresser.PressState;
 import growthcraft.cellar.shared.CellarRegistry;
 import growthcraft.cellar.shared.processing.common.Residue;
-import growthcraft.cellar.shared.processing.fermenting.IFermentationRecipe;
 import growthcraft.cellar.shared.processing.pressing.IPressingRecipe;
 import growthcraft.cellar.common.tileentity.TileEntityCellarDevice;
-import growthcraft.core.shared.fluids.GrowthcraftFluidUtils;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.device.DeviceProgressive;
@@ -55,16 +53,15 @@ public class FruitPress extends DeviceProgressive<IPressingRecipe> {
     @Override
     protected boolean canProcess() {
         IPressingRecipe recipe = getWorkingRecipe();
-        if (inputSlot.get() == null) return false;
-        if (fluidSlot.isFull()) return false;
+        if(recipe == null) return false;
+        //Checks for input items
+        if(!recipe.getInput().containsItemStack(inputSlot.get())) return false;
+        //Checks for output fluids
+        if(!fluidSlot.hasCapacityFor(recipe.getFluidStack())) return false;
+        //Checks for output items
+        if(!residueSlot.hasCapacityFor(recipe.getResidue().residueItem)) return false;
 
-        if (recipe == null) return false;
-        if (!inputSlot.hasEnough((recipe.getInput()))) return false;
-
-        if (fluidSlot.isEmpty()) return true;
-
-        final FluidStack stack = recipe.getFluidStack();
-        return stack.isFluidEqual(fluidSlot.get());
+        return true;
     }
 
     public void producePomace() {
@@ -83,7 +80,6 @@ public class FruitPress extends DeviceProgressive<IPressingRecipe> {
 
     @Override
     public void process(IPressingRecipe recipe) {
-        final ItemStack pressingItem = inputSlot.get();
         producePomace();
         final FluidStack fluidstack = recipe.getFluidStack();
         fluidSlot.fill(fluidstack, true);

--- a/src/main/java/growthcraft/cellar/common/tileentity/device/YeastGenerator.java
+++ b/src/main/java/growthcraft/cellar/common/tileentity/device/YeastGenerator.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import growthcraft.cellar.shared.CellarRegistry;
 import growthcraft.cellar.shared.booze.BoozeTag;
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import growthcraft.cellar.shared.processing.yeast.YeastRegistry;
 import growthcraft.cellar.common.tileentity.TileEntityCellarDevice;
 import growthcraft.core.shared.CoreRegistry;
@@ -80,7 +81,8 @@ public class YeastGenerator extends DeviceProgressive {
      *
      * @return true, the generator can produce yeast, false otherwise
      */
-    public boolean canProduceYeast() {
+    @Override
+    public boolean canProcess() {
         if (fluidSlot.getAmount() < consumption) return false;
         final ItemStack yeastItem = invSlot.get();
         // we can ignore null items, this will fallback to the initProduceYeast
@@ -134,7 +136,8 @@ public class YeastGenerator extends DeviceProgressive {
         }
     }
 
-    public void produceYeast() {
+    @Override
+    public void process(IProcessingRecipeBase recipe) {
         if (invSlot.isEmpty()) {
             initProduceYeast();
         } else {
@@ -153,15 +156,6 @@ public class YeastGenerator extends DeviceProgressive {
 
     @Override
     public void update() {
-        if (canProduceYeast()) {
-            increaseTime();
-            if (time >= timeMax) {
-                resetTime();
-                produceYeast();
-                markDirty();
-            }
-        } else {
-            if (resetTime()) markDirty();
-        }
+        super.update();
     }
 }

--- a/src/main/java/growthcraft/cellar/shared/processing/common/IProcessingRecipe.java
+++ b/src/main/java/growthcraft/cellar/shared/processing/common/IProcessingRecipe.java
@@ -3,12 +3,10 @@ package growthcraft.cellar.shared.processing.common;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-public interface IProcessingRecipe {
+public interface IProcessingRecipe extends IProcessingRecipeBase{
     Residue getResidue();
 
     boolean hasResidue();
-
-    int getTime();
 
     Fluid getFluid();
 

--- a/src/main/java/growthcraft/cellar/shared/processing/common/IProcessingRecipeBase.java
+++ b/src/main/java/growthcraft/cellar/shared/processing/common/IProcessingRecipeBase.java
@@ -1,0 +1,6 @@
+package growthcraft.cellar.shared.processing.common;
+
+public interface IProcessingRecipeBase {
+
+    int getTime();
+}

--- a/src/main/java/growthcraft/cellar/shared/processing/culturing/ICultureRecipe.java
+++ b/src/main/java/growthcraft/cellar/shared/processing/culturing/ICultureRecipe.java
@@ -1,17 +1,16 @@
 package growthcraft.cellar.shared.processing.culturing;
 
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-public interface ICultureRecipe {
+public interface ICultureRecipe extends IProcessingRecipeBase {
 
     ItemStack getOutputItemStack();
 
     FluidStack getInputFluidStack();
 
     float getRequiredHeat();
-
-    int getTime();
 
     boolean matchesRecipe(FluidStack fluid, float heat);
 

--- a/src/main/java/growthcraft/cellar/shared/processing/fermenting/IFermentationRecipe.java
+++ b/src/main/java/growthcraft/cellar/shared/processing/fermenting/IFermentationRecipe.java
@@ -2,12 +2,13 @@ package growthcraft.cellar.shared.processing.fermenting;
 
 import javax.annotation.Nullable;
 
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import growthcraft.core.shared.definition.IMultiFluidStacks;
 import growthcraft.core.shared.definition.IMultiItemStacks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-public interface IFermentationRecipe {
+public interface IFermentationRecipe extends IProcessingRecipeBase {
 
     IMultiFluidStacks getInputFluidStack();
 

--- a/src/main/java/growthcraft/core/shared/tileentity/GrowthcraftTileDeviceBase.java
+++ b/src/main/java/growthcraft/core/shared/tileentity/GrowthcraftTileDeviceBase.java
@@ -1,8 +1,6 @@
 package growthcraft.core.shared.tileentity;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -19,7 +17,6 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;

--- a/src/main/java/growthcraft/core/shared/tileentity/GrowthcraftTileDeviceBase.java
+++ b/src/main/java/growthcraft/core/shared/tileentity/GrowthcraftTileDeviceBase.java
@@ -1,6 +1,8 @@
 package growthcraft.core.shared.tileentity;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.Nullable;
 
@@ -8,11 +10,16 @@ import growthcraft.core.shared.fluids.FluidTest;
 import growthcraft.core.shared.handlers.FluidHandlerBlockWrapper;
 import growthcraft.core.shared.fluids.FluidTanks;
 import growthcraft.core.shared.fluids.IFluidTanks;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
+import growthcraft.core.shared.tileentity.device.DeviceProgressive;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.IFluidTankOperable;
+import growthcraft.core.shared.tileentity.feature.ITileDevice;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -24,7 +31,7 @@ import net.minecraftforge.fluids.capability.IFluidTankProperties;
 /**
  * Extend this base class if you want a base class with an `Inventory` and `Fluid Tanks`
  */
-public abstract class GrowthcraftTileDeviceBase extends GrowthcraftTileInventoryBase implements IFluidTankOperable, IFluidTanks {
+public abstract class GrowthcraftTileDeviceBase extends GrowthcraftTileInventoryBase implements IFluidTankOperable, IFluidTanks,ITileDevice {
     private FluidTanks tanks;
 
     public GrowthcraftTileDeviceBase() {
@@ -32,9 +39,31 @@ public abstract class GrowthcraftTileDeviceBase extends GrowthcraftTileInventory
         this.tanks = new FluidTanks(createTanks());
     }
 
+
+
     protected void markFluidDirty() {
         markDirty();
+        if(getWorld().isRemote){return;}
+        for(DeviceBase dev : getDevices()){
+            if(dev instanceof DeviceProgressive){
+                ((DeviceProgressive) dev).markForRecipeRecheck();
+            }
+        }
     }
+
+    @Override
+    public void onInventoryChanged(IInventory inv, int index) {
+        super.onInventoryChanged(inv, index);
+        //I don't know why getWorld would return null
+        if(getWorld() == null){return;}
+        if(getWorld().isRemote){return;}
+        for(DeviceBase dev : getDevices()){
+            if(dev instanceof DeviceProgressive){
+                ((DeviceProgressive) dev).markForRecipeRecheck();
+            }
+        }
+    }
+
 
     protected FluidTank[] createTanks() {
         return new FluidTank[]{};

--- a/src/main/java/growthcraft/core/shared/tileentity/device/DeviceProgressive.java
+++ b/src/main/java/growthcraft/core/shared/tileentity/device/DeviceProgressive.java
@@ -1,28 +1,83 @@
 package growthcraft.core.shared.tileentity.device;
 
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 
-public class DeviceProgressive extends DeviceBase {
-    protected int time;
+public class DeviceProgressive<T extends IProcessingRecipeBase> extends DeviceBase {
+    protected double time;
     protected int timeMax;
+    //protected boolean shouldUseCachedRecipe = GrowthcraftCellarConfig.fermentBarrelUseCachedRecipe;
+    protected boolean recheckRecipe = true;
+    private T activeRecipe;
 
     public DeviceProgressive(TileEntity te) {
         super(te);
     }
 
+    //TODO:Move to DeviceBase, or make a DeviceRecipe class?
+    //Buffered recipe logic
+
+    protected T loadRecipe() {
+        return null;
+    }
+
+    public void markForRecipeRecheck() {
+        this.recheckRecipe = true;
+    }
+
+    public T refreshRecipe() {
+        final T recipe = loadRecipe();
+        if (recipe != null && recipe != activeRecipe) {
+            if (activeRecipe != null) {
+                resetTime();
+            }
+            this.activeRecipe = recipe;
+            markDirty();
+        } else {
+            if (recipe == null && activeRecipe != null) {
+                activeRecipe = null;
+                resetTime();
+                markDirty();
+            }
+        }
+        this.recheckRecipe = false;
+        return activeRecipe;
+    }
+
+    protected boolean canProcess(){return activeRecipe != null;}
+
+    protected void process(T recipe){if(!canProcess()) return;}
+
+    public T getWorkingRecipe() {
+        if (recheckRecipe) {refreshRecipe();}
+        return activeRecipe;
+    }
+
+    //Progress and time related stuff
+
+    protected float getSpeedMultiplier(){
+        return 1f;
+    }
+
     public float getProgress() {
-        if (timeMax <= 0) return 0f;
-        return (float) time / timeMax;
+        final int tmx = getTimeMax();
+        if (tmx > 0) {
+            return (float) time / (float) tmx;
+        }
+        return 0.0f;
     }
 
     public int getProgressScaled(int scale) {
-        if (timeMax <= 0) return 0;
-        return this.time * scale / timeMax;
+        final int tmx = getTimeMax();
+        if (tmx > 0) {
+            return (int) this.time * scale / tmx;
+        }
+        return 0;
     }
 
-    public int getTime() {
+    public double getTime() {
         return time;
     }
 
@@ -38,6 +93,9 @@ public class DeviceProgressive extends DeviceBase {
         this.timeMax = t;
     }
 
+    /**
+     * @return time was reset, false otherwise
+     */
     public boolean resetTime() {
         if (this.time != 0) {
             setTime(0);
@@ -48,11 +106,25 @@ public class DeviceProgressive extends DeviceBase {
 
 
     public void increaseTime() {
-        time++;
+        time+=getSpeedMultiplier();
     }
 
     public void update() {
+
+        final T recipe = getWorkingRecipe();
+        if (canProcess()) {
+            setTimeMax(recipe.getTime());
+            increaseTime();
+            if (time >= timeMax) {
+                resetTime();
+                process(recipe);
+            }
+        } else {
+            if (resetTime()) markForUpdate(true);
+        }
     }
+
+    //Data stuff
 
     /**
      * @param data - nbt data to read from
@@ -60,7 +132,7 @@ public class DeviceProgressive extends DeviceBase {
     @Override
     public void readFromNBT(NBTTagCompound data) {
         super.readFromNBT(data);
-        this.time = data.getInteger("time");
+        this.time = data.getDouble("time");
         //this.timeMax = data.getInteger("timeMax");
     }
 
@@ -70,7 +142,7 @@ public class DeviceProgressive extends DeviceBase {
     @Override
     public void writeToNBT(NBTTagCompound data) {
         super.writeToNBT(data);
-        data.setInteger("time", time);
+        data.setDouble("time", time);
         //data.setInteger("timeMax", timeMax);
     }
 
@@ -80,7 +152,7 @@ public class DeviceProgressive extends DeviceBase {
     @Override
     public boolean readFromStream(ByteBuf buf) {
         super.readFromStream(buf);
-        this.time = buf.readInt();
+        this.time = buf.readDouble();
         //this.timeMax = buf.readInt();
         return false;
     }
@@ -91,7 +163,7 @@ public class DeviceProgressive extends DeviceBase {
     @Override
     public boolean writeToStream(ByteBuf buf) {
         super.writeToStream(buf);
-        buf.writeInt(time);
+        buf.writeDouble(time);
         //buf.writeInt(timeMax);
         return false;
     }

--- a/src/main/java/growthcraft/core/shared/tileentity/device/DeviceProgressive.java
+++ b/src/main/java/growthcraft/core/shared/tileentity/device/DeviceProgressive.java
@@ -1,9 +1,9 @@
 package growthcraft.core.shared.tileentity.device;
 
 import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
+import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
 
 public class DeviceProgressive<T extends IProcessingRecipeBase> extends DeviceBase {
     protected double time;
@@ -12,7 +12,7 @@ public class DeviceProgressive<T extends IProcessingRecipeBase> extends DeviceBa
     protected boolean recheckRecipe = true;
     private T activeRecipe;
 
-    public DeviceProgressive(TileEntity te) {
+    public DeviceProgressive(GrowthcraftTileDeviceBase te) {
         super(te);
     }
 
@@ -114,10 +114,11 @@ public class DeviceProgressive<T extends IProcessingRecipeBase> extends DeviceBa
         final T recipe = getWorkingRecipe();
         if (canProcess()) {
             setTimeMax(recipe.getTime());
-            increaseTime();
             if (time >= timeMax) {
-                resetTime();
                 process(recipe);
+                resetTime();
+            }else{
+                increaseTime();
             }
         } else {
             if (resetTime()) markForUpdate(true);

--- a/src/main/java/growthcraft/core/shared/tileentity/feature/ITileDevice.java
+++ b/src/main/java/growthcraft/core/shared/tileentity/feature/ITileDevice.java
@@ -1,0 +1,8 @@
+package growthcraft.core.shared.tileentity.feature;
+
+import growthcraft.core.shared.tileentity.device.DeviceBase;
+
+public interface ITileDevice {
+
+    DeviceBase[] getDevices();
+}

--- a/src/main/java/growthcraft/core/shared/tileentity/feature/ITileProgressiveDevice.java
+++ b/src/main/java/growthcraft/core/shared/tileentity/feature/ITileProgressiveDevice.java
@@ -1,6 +1,6 @@
 package growthcraft.core.shared.tileentity.feature;
 
-public interface ITileProgressiveDevice {
+public interface ITileProgressiveDevice extends ITileDevice{
     float getDeviceProgress();
 
     int getDeviceProgressScaled(int scale);

--- a/src/main/java/growthcraft/milk/common/lib/processing/DriedCurdsCheesePressRecipe.java
+++ b/src/main/java/growthcraft/milk/common/lib/processing/DriedCurdsCheesePressRecipe.java
@@ -28,7 +28,7 @@ public class DriedCurdsCheesePressRecipe implements ICheesePressRecipe {
     }
 
     @Override
-    public int getTimeMax() {
+    public int getTime() {
         return time;
     }
 
@@ -49,4 +49,6 @@ public class DriedCurdsCheesePressRecipe implements ICheesePressRecipe {
     public String toString() {
         return String.format("DriedCurdsCheesePressRecipe({%s} / %d = {%s})", getOutputItemStack(), time, getInputItemStack());
     }
+
+
 }

--- a/src/main/java/growthcraft/milk/common/tileentity/TileEntityButterChurn.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/TileEntityButterChurn.java
@@ -6,6 +6,7 @@ import growthcraft.core.shared.fluids.FluidTest;
 import growthcraft.core.shared.inventory.AccesibleSlots;
 import growthcraft.core.shared.inventory.GrowthcraftInternalInventory;
 import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
@@ -43,6 +44,9 @@ public class TileEntityButterChurn extends GrowthcraftTileDeviceBase implements 
     private DeviceFluidSlot inputFluidSlot = new DeviceFluidSlot(this, 0);
     private DeviceFluidSlot outputFluidSlot = new DeviceFluidSlot(this, 1);
     private DeviceInventorySlot outputInventorySlot = new DeviceInventorySlot(this, 0);
+
+    @Override
+    public DeviceBase[] getDevices(){return new DeviceBase[]{};}
 
     @Override
     protected FluidTank[] createTanks() {

--- a/src/main/java/growthcraft/milk/common/tileentity/TileEntityButterChurn.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/TileEntityButterChurn.java
@@ -12,6 +12,7 @@ import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.IItemOperable;
 import growthcraft.core.shared.item.ItemUtils;
+import growthcraft.milk.common.tileentity.device.Churn;
 import growthcraft.milk.shared.MilkRegistry;
 import growthcraft.milk.shared.processing.churn.IChurnRecipe;
 import io.netty.buffer.ByteBuf;
@@ -27,12 +28,12 @@ public class TileEntityButterChurn extends GrowthcraftTileDeviceBase implements 
     public static enum WorkState {
         NONE,
         CHURN,
-        PRODUCE;
+        PRODUCE
     }
 
     private static AccesibleSlots accessibleSlots = new AccesibleSlots(new int[][]{
             {0},
-            {},
+            {0},
             {0},
             {0},
             {0},
@@ -40,13 +41,13 @@ public class TileEntityButterChurn extends GrowthcraftTileDeviceBase implements 
     });
 
     private int shaftState;
-    private int churns;
     private DeviceFluidSlot inputFluidSlot = new DeviceFluidSlot(this, 0);
     private DeviceFluidSlot outputFluidSlot = new DeviceFluidSlot(this, 1);
     private DeviceInventorySlot outputInventorySlot = new DeviceInventorySlot(this, 0);
 
+    private Churn churn = new Churn(this, 0,1,0);
     @Override
-    public DeviceBase[] getDevices(){return new DeviceBase[]{};}
+    public DeviceBase[] getDevices(){return new DeviceBase[]{churn};}
 
     @Override
     protected FluidTank[] createTanks() {
@@ -87,42 +88,17 @@ public class TileEntityButterChurn extends GrowthcraftTileDeviceBase implements 
         return accessibleSlots.sideContains(side, index);
     }
 
-    private IChurnRecipe getWorkingRecipe() {
-        final FluidStack stack = inputFluidSlot.get();
-        if (stack != null) {
-            final IChurnRecipe recipe = MilkRegistry.instance().churn().getRecipe(stack);
-            return recipe;
-        }
-        return null;
-    }
 
     public WorkState doWork() {
         WorkState state = WorkState.NONE;
-        final IChurnRecipe recipe = getWorkingRecipe();
-        if (recipe != null) {
-            state = WorkState.CHURN;
-            this.churns++;
-            if (churns >= recipe.getChurns()) {
-                this.churns = 0;
-                inputFluidSlot.consume(recipe.getInputFluidStack(), true);
-                outputFluidSlot.fill(recipe.getOutputFluidStack(), true);
-                outputInventorySlot.increaseStack(recipe.getOutputItemStack());
-                state = WorkState.PRODUCE;
-            }
-
-            if (shaftState == 0) {
+        if (shaftState == 0) {
                 this.shaftState = 1;
-            } else {
-                this.shaftState = 0;
-            }
-            markForUpdate(true);
+                churn.update();
         } else {
-            if (shaftState != 0) {
                 this.shaftState = 0;
-                markForUpdate(true);
-            }
-            this.churns = 0;
+                churn.update();
         }
+        markForUpdate(true);
         return state;
     }
 
@@ -177,7 +153,7 @@ public class TileEntityButterChurn extends GrowthcraftTileDeviceBase implements 
 //		if (dir == EnumFacing.UP) return 0;
         int result = 0;
 
-        if (MilkRegistry.instance().churn().isFluidIngredient(stack)) {
+        if (canFill(dir, stack.getFluid())) {
             result = inputFluidSlot.fill(stack, doFill);
         }
 
@@ -217,26 +193,22 @@ public class TileEntityButterChurn extends GrowthcraftTileDeviceBase implements 
     @TileEventHandler(event = TileEventHandler.EventType.NBT_READ)
     public void readFromNBT_ButterChurn(NBTTagCompound nbt) {
         this.shaftState = nbt.getInteger("shaft_state");
-        this.churns = nbt.getInteger("churns");
     }
 
     @TileEventHandler(event = TileEventHandler.EventType.NBT_WRITE)
     public void writeToNBT_ButterChurn(NBTTagCompound nbt) {
         nbt.setInteger("shaft_state", shaftState);
-        nbt.setInteger("churns", churns);
     }
 
     @TileEventHandler(event = TileEventHandler.EventType.NETWORK_READ)
     public boolean readFromStream_ButterChurn(ByteBuf stream) throws IOException {
         this.shaftState = stream.readInt();
-        this.churns = stream.readInt();
         return false;
     }
 
     @TileEventHandler(event = TileEventHandler.EventType.NETWORK_WRITE)
     public boolean writeToStream_ButterChurn(ByteBuf stream) throws IOException {
         stream.writeInt(shaftState);
-        stream.writeInt(churns);
         return false;
     }
 }

--- a/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheesePress.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheesePress.java
@@ -13,8 +13,6 @@ import growthcraft.core.shared.tileentity.feature.IItemOperable;
 import growthcraft.core.shared.tileentity.feature.ITileProgressiveDevice;
 import growthcraft.milk.common.item.ItemBlockHangingCurds;
 import growthcraft.milk.common.tileentity.device.CheesePress;
-import growthcraft.milk.shared.MilkRegistry;
-import growthcraft.milk.shared.processing.cheesepress.ICheesePressRecipe;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;

--- a/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheesePress.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheesePress.java
@@ -5,13 +5,14 @@ import java.io.IOException;
 import growthcraft.core.shared.inventory.GrowthcraftInternalInventory;
 import growthcraft.core.shared.item.ItemTest;
 import growthcraft.core.shared.item.ItemUtils;
-import growthcraft.core.shared.tileentity.GrowthcraftTileInventoryBase;
+import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.IItemOperable;
 import growthcraft.core.shared.tileentity.feature.ITileProgressiveDevice;
 import growthcraft.milk.common.item.ItemBlockHangingCurds;
+import growthcraft.milk.common.tileentity.device.CheesePress;
 import growthcraft.milk.shared.MilkRegistry;
 import growthcraft.milk.shared.processing.cheesepress.ICheesePressRecipe;
 import io.netty.buffer.ByteBuf;
@@ -25,7 +26,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class TileEntityCheesePress extends GrowthcraftTileInventoryBase implements ITickable, IItemOperable, ITileProgressiveDevice {
+public class TileEntityCheesePress extends GrowthcraftTileDeviceBase implements ITickable, IItemOperable, ITileProgressiveDevice {
     private static int[][] accessibleSlots = {
             {0},
             {0},
@@ -41,53 +42,20 @@ public class TileEntityCheesePress extends GrowthcraftTileInventoryBase implemen
     public float animProgress;
     @SideOnly(Side.CLIENT)
     public int animDir;
-
     private int screwState;
     private DeviceInventorySlot invSlot = new DeviceInventorySlot(this, 0);
-    private int time;
-    private boolean needRecipeRecheck = true;
-    private ICheesePressRecipe workingRecipe;
-
+    private final CheesePress cheesePress = new CheesePress(this);
     @Override
-    public DeviceBase[] getDevices(){return new DeviceBase[]{};}
-
-    public void markForRecipeCheck() {
-        this.needRecipeRecheck = true;
-    }
-
-    private void setupWorkingRecipe() {
-        final ICheesePressRecipe recipe = MilkRegistry.instance().cheesePress().findRecipe(invSlot.get());
-        if (recipe != workingRecipe) {
-            if (workingRecipe != null) {
-                this.time = 0;
-            }
-            this.workingRecipe = recipe;
-        }
-    }
-
-    protected ICheesePressRecipe getWorkingRecipe() {
-        if (workingRecipe == null) {
-            setupWorkingRecipe();
-        }
-        return workingRecipe;
-    }
+    public DeviceBase[] getDevices(){return new DeviceBase[]{cheesePress};}
 
     @Override
     public float getDeviceProgress() {
-        final ICheesePressRecipe recipe = getWorkingRecipe();
-        if (recipe != null) {
-            return (float) time / (float) recipe.getTimeMax();
-        }
-        return 0.0f;
+        return cheesePress.getProgress();
     }
 
     @Override
     public int getDeviceProgressScaled(int scale) {
-        final ICheesePressRecipe recipe = getWorkingRecipe();
-        if (recipe != null) {
-            return time * scale / recipe.getTimeMax();
-        }
-        return 0;
+        return cheesePress.getProgressScaled(scale);
     }
 
     public boolean isPressed() {
@@ -106,7 +74,7 @@ public class TileEntityCheesePress extends GrowthcraftTileInventoryBase implemen
     @Override
     public void onInventoryChanged(IInventory inv, int index) {
         super.onInventoryChanged(inv, index);
-        markForRecipeCheck();
+        cheesePress.markForRecipeRecheck();
     }
 
     @Override
@@ -162,41 +130,10 @@ public class TileEntityCheesePress extends GrowthcraftTileInventoryBase implemen
 			isAnim = true;*/
     }
 
-    private void commitRecipe() {
-        final ICheesePressRecipe recipe = getWorkingRecipe();
-        if (recipe != null) {
-            invSlot.set(recipe.getOutputItemStack().copy());
-            this.workingRecipe = null;
-        }
-    }
+
 
     private void updateEntityServer() {
-        if (needRecipeRecheck) {
-            needRecipeRecheck = false;
-            setupWorkingRecipe();
-        }
-
-        final ICheesePressRecipe recipe = getWorkingRecipe();
-        if (recipe != null) {
-            // work can only progress if the cheese press is active.
-            if (isPressed()) {
-                if (time < recipe.getTimeMax()) {
-                    time++;
-                } else {
-                    this.time = 0;
-                    commitRecipe();
-                }
-            }
-            // otherwise the cheese press will lose its progress?
-            else {
-                if (time > 0) time--;
-            }
-        } else {
-            if (time != 0) {
-                this.time = 0;
-                markDirty();
-            }
-        }
+        cheesePress.update();
     }
 
     @Override
@@ -274,26 +211,22 @@ public class TileEntityCheesePress extends GrowthcraftTileInventoryBase implemen
     @TileEventHandler(event = TileEventHandler.EventType.NBT_READ)
     public void readFromNBT_CheesePress(NBTTagCompound nbt) {
         this.screwState = nbt.getInteger("screw_state");
-        this.time = nbt.getInteger("time");
     }
 
     @TileEventHandler(event = TileEventHandler.EventType.NBT_WRITE)
     public void writeToNBT_CheesePress(NBTTagCompound nbt) {
         nbt.setInteger("screw_state", screwState);
-        nbt.setInteger("time", time);
     }
 
     @TileEventHandler(event = TileEventHandler.EventType.NETWORK_READ)
     public boolean readFromStream_CheesePress(ByteBuf stream) throws IOException {
         this.screwState = stream.readInt();
-        this.time = stream.readInt();
         return false;
     }
 
     @TileEventHandler(event = TileEventHandler.EventType.NETWORK_WRITE)
     public boolean writeToStream_CheesePress(ByteBuf stream) throws IOException {
         stream.writeInt(screwState);
-        stream.writeInt(time);
         return false;
     }
 }

--- a/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheesePress.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheesePress.java
@@ -6,6 +6,7 @@ import growthcraft.core.shared.inventory.GrowthcraftInternalInventory;
 import growthcraft.core.shared.item.ItemTest;
 import growthcraft.core.shared.item.ItemUtils;
 import growthcraft.core.shared.tileentity.GrowthcraftTileInventoryBase;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.IItemOperable;
@@ -46,6 +47,9 @@ public class TileEntityCheesePress extends GrowthcraftTileInventoryBase implemen
     private int time;
     private boolean needRecipeRecheck = true;
     private ICheesePressRecipe workingRecipe;
+
+    @Override
+    public DeviceBase[] getDevices(){return new DeviceBase[]{};}
 
     public void markForRecipeCheck() {
         this.needRecipeRecheck = true;

--- a/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheeseVat.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/TileEntityCheeseVat.java
@@ -13,6 +13,7 @@ import growthcraft.core.shared.item.ItemTest;
 import growthcraft.core.shared.item.ItemUtils;
 import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
 import growthcraft.core.shared.tileentity.component.TileHeatingComponent;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.event.TileEventHandler;
 import growthcraft.core.shared.tileentity.feature.IItemOperable;
@@ -53,6 +54,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class TileEntityCheeseVat extends GrowthcraftTileDeviceBase implements ITickable, IItemOperable, ITileHeatedDevice, ITileNamedFluidTanks, ITileProgressiveDevice {
+
+
     public static enum FluidTankType {
         PRIMARY,
         RENNET,
@@ -91,6 +94,11 @@ public class TileEntityCheeseVat extends GrowthcraftTileDeviceBase implements IT
     private CheeseVatState vatState = CheeseVatState.IDLE;
     private float progress;
     private int progressMax;
+
+    @Override
+    public DeviceBase[] getDevices() {
+        return new DeviceBase[]{};
+    }
 
     public boolean isIdle() {
         return vatState == CheeseVatState.IDLE;

--- a/src/main/java/growthcraft/milk/common/tileentity/TileEntityPancheon.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/TileEntityPancheon.java
@@ -2,6 +2,7 @@ package growthcraft.milk.common.tileentity;
 
 import growthcraft.core.shared.fluids.FluidTest;
 import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
+import growthcraft.core.shared.tileentity.device.DeviceBase;
 import growthcraft.core.shared.tileentity.feature.IFluidTankOperable;
 import growthcraft.core.shared.tileentity.feature.ITileProgressiveDevice;
 import growthcraft.milk.common.tileentity.device.Pancheon;
@@ -12,6 +13,9 @@ import net.minecraftforge.fluids.FluidTank;
 
 public class TileEntityPancheon extends GrowthcraftTileDeviceBase implements ITickable, ITileProgressiveDevice, IPancheonTile {
     private Pancheon pancheon = new Pancheon(this, 0, 2, 1);
+
+    @Override
+    public DeviceBase[] getDevices(){return new DeviceBase[]{pancheon};}
 
     @Override
     public float getDeviceProgress() {

--- a/src/main/java/growthcraft/milk/common/tileentity/device/CheesePress.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/device/CheesePress.java
@@ -1,0 +1,48 @@
+package growthcraft.milk.common.tileentity.device;
+
+import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
+import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
+import growthcraft.core.shared.tileentity.device.DeviceProgressive;
+import growthcraft.milk.common.tileentity.TileEntityCheesePress;
+import growthcraft.milk.shared.MilkRegistry;
+import growthcraft.milk.shared.processing.cheesepress.ICheesePressRecipe;
+
+public class CheesePress extends DeviceProgressive<ICheesePressRecipe> {
+
+    private DeviceInventorySlot invSlot;
+
+    public CheesePress(GrowthcraftTileDeviceBase te) {
+        super(te);
+        invSlot = new DeviceInventorySlot(te, 0);
+    }
+
+    @Override
+    protected ICheesePressRecipe loadRecipe() {
+        return MilkRegistry.instance().cheesePress().findRecipe(invSlot.get());
+    }
+
+    @Override
+    protected boolean canProcess() {
+        ICheesePressRecipe recipe = getWorkingRecipe();
+        if (invSlot.get() == null) return false;
+        if (recipe == null) return false;
+        if (!invSlot.hasEnough((recipe.getInputItemStack()))) return false;
+        return true;
+    }
+
+    @Override
+    protected float getSpeedMultiplier(){
+        if(parent instanceof TileEntityCheesePress){
+            return super.getSpeedMultiplier()*(((TileEntityCheesePress) parent).isPressed()? 1:0);
+        }else{
+            return super.getSpeedMultiplier();
+        }
+    }
+
+    @Override
+    public void process(ICheesePressRecipe recipe) {
+        if (recipe != null) {
+            invSlot.set(recipe.getOutputItemStack().copy());
+        }
+    }
+}

--- a/src/main/java/growthcraft/milk/common/tileentity/device/CheeseVat.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/device/CheeseVat.java
@@ -1,0 +1,88 @@
+package growthcraft.milk.common.tileentity.device;
+
+import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
+import growthcraft.core.shared.tileentity.component.TileHeatingComponent;
+import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
+import growthcraft.core.shared.tileentity.device.DeviceProgressive;
+import growthcraft.milk.shared.processing.cheesevat.ICheeseVatRecipe;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class CheeseVat extends DeviceProgressive<ICheeseVatRecipe> {
+    private DeviceFluidSlot primaryFluidSlot;
+    private DeviceFluidSlot rennetFluidSlot;
+    private DeviceFluidSlot wasteFluidSlot;
+    private TileHeatingComponent heatComponent;
+
+
+
+    public CheeseVat(GrowthcraftTileDeviceBase te, int primFluidSlot_id, int rennetFluidSlot_id, int wasteFluidSlot_id) {
+        super(te);
+        primaryFluidSlot = new DeviceFluidSlot(te,primFluidSlot_id);
+        rennetFluidSlot = new DeviceFluidSlot(te, rennetFluidSlot_id);
+        wasteFluidSlot = new DeviceFluidSlot(te, wasteFluidSlot_id);
+        this.heatComponent = new TileHeatingComponent(te, 0.5f);
+    }
+
+
+    public CheeseVat setHeatMultiplier(float h) {
+        heatComponent.setHeatMultiplier(h);
+        return this;
+    }
+
+    public float getHeatMultiplier() {
+        return heatComponent.getHeatMultiplier();
+    }
+
+    public boolean isHeated() {
+        return getHeatMultiplier() > 0;
+    }
+    @Override
+    protected ICheeseVatRecipe loadRecipe() {
+        //ICheeseVatRecipe recipe = MilkRegistry.instance().cheeseVat().findRecipe(fluids, items);
+        return null;
+    }
+
+    @Override
+    protected boolean canProcess() {
+        ICheeseVatRecipe recipe = getWorkingRecipe();
+        if (recipe == null) return false;
+
+        return false;
+    }
+
+
+
+    //Data stuff
+    @Override
+    public void readFromNBT(NBTTagCompound data) {
+        super.readFromNBT(data);
+        heatComponent.readFromNBT(data, "heat_component");
+    }
+
+    @Override
+    public void writeToNBT(NBTTagCompound data) {
+        super.writeToNBT(data);
+        heatComponent.writeToNBT(data, "heat_component");
+    }
+
+    /**
+     * @param buf - buffer to read from
+     */
+    @Override
+    public boolean readFromStream(ByteBuf buf) {
+        super.readFromStream(buf);
+        heatComponent.readFromStream(buf);
+        return false;
+    }
+
+    /**
+     * @param buf - buffer to write to
+     */
+    @Override
+    public boolean writeToStream(ByteBuf buf) {
+        super.writeToStream(buf);
+        heatComponent.writeToStream(buf);
+        return false;
+    }
+}

--- a/src/main/java/growthcraft/milk/common/tileentity/device/Churn.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/device/Churn.java
@@ -1,0 +1,67 @@
+package growthcraft.milk.common.tileentity.device;
+
+import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
+import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
+import growthcraft.core.shared.tileentity.device.DeviceInventorySlot;
+import growthcraft.core.shared.tileentity.device.DeviceProgressive;
+import growthcraft.milk.shared.MilkRegistry;
+import growthcraft.milk.shared.processing.churn.IChurnRecipe;
+
+public class Churn extends DeviceProgressive<IChurnRecipe> {
+
+    private DeviceFluidSlot inputFluidSlot;
+    private DeviceFluidSlot outputFluidSlot;
+    private DeviceInventorySlot outputSlot;
+
+    public Churn(GrowthcraftTileDeviceBase te, int inputFluidSlot, int outputFluidSlot, int outputSlot) {
+        super(te);
+        this.outputFluidSlot = new DeviceFluidSlot(te, outputFluidSlot);
+        this.inputFluidSlot = new DeviceFluidSlot(te, inputFluidSlot);
+        this.outputSlot = new DeviceInventorySlot(te, outputSlot);
+    }
+
+    @Override
+    protected IChurnRecipe loadRecipe() {
+        return MilkRegistry.instance().churn().getRecipe(inputFluidSlot.get());
+    }
+
+    @Override
+    protected boolean canProcess() {
+        IChurnRecipe recipe = getWorkingRecipe();
+        if(recipe == null) return false;
+        //Checks for input fluids
+        if(!inputFluidSlot.hasEnough(recipe.getInputFluidStack())) return false;
+        //Checks for input items
+        //Checks for output fluids
+        if(!outputFluidSlot.hasCapacityFor(recipe.getOutputFluidStack())) return false;
+        //Checks for output items
+        if(!outputSlot.hasCapacityFor(recipe.getOutputItemStack())) return false;
+
+        return true;
+    }
+
+    @Override
+    public void process(IChurnRecipe recipe) {
+        inputFluidSlot.consume(recipe.getInputFluidStack(), true);
+        outputFluidSlot.fill(recipe.getOutputFluidStack(),true);
+        outputSlot.increaseStack(recipe.getOutputItemStack());
+    }
+
+    //Churns
+    //Using the time as a number of churns
+    @Override
+    public void update() {
+        final IChurnRecipe recipe = getWorkingRecipe();
+        if (canProcess()) {
+            setTimeMax(recipe.getChurns());
+            increaseTime();
+            if (time >= timeMax) {
+                resetTime();
+                process(recipe);
+            }
+        } else {
+            if (resetTime()) markForUpdate(true);
+        }
+    }
+
+}

--- a/src/main/java/growthcraft/milk/common/tileentity/device/Pancheon.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/device/Pancheon.java
@@ -8,7 +8,7 @@ import growthcraft.milk.shared.processing.pancheon.IPancheonRecipe;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fluids.FluidStack;
 
-public class Pancheon extends DeviceProgressive {
+public class Pancheon extends DeviceProgressive<IPancheonRecipe> {
     private DeviceFluidSlot inputSlot;
     private DeviceFluidSlot topSlot;
     private DeviceFluidSlot bottomSlot;
@@ -36,28 +36,21 @@ public class Pancheon extends DeviceProgressive {
      *
      * @return recipe
      */
-    private IPancheonRecipe getRecipe() {
-        return MilkRegistry.instance().pancheon().getRecipe(inputSlot.get());
-    }
-
-    /**
-     * Get the matching recipe AND it can be worked on with the current pancheon
-     *
-     * @return recipe
-     */
-    public IPancheonRecipe getWorkingRecipe() {
-        final IPancheonRecipe recipe = getRecipe();
+    @Override
+    protected IPancheonRecipe loadRecipe() {
+        IPancheonRecipe recipe = MilkRegistry.instance().pancheon().getRecipe(inputSlot.get());
         if (recipe == null) return null;
         if (!this.topSlot.hasMatchingWithCapacity(recipe.getTopOutputFluid())) return null;
         if (!this.bottomSlot.hasMatchingWithCapacity(recipe.getBottomOutputFluid())) return null;
         return recipe;
     }
 
+
     /**
      * Complete the process and commit the changes
      */
     private void commitRecipe() {
-        final IPancheonRecipe recipe = getRecipe();
+        final IPancheonRecipe recipe = loadRecipe();
         if (recipe != null) {
             this.inputSlot.consume(recipe.getInputFluid().amount, true);
 

--- a/src/main/java/growthcraft/milk/common/tileentity/device/Pancheon.java
+++ b/src/main/java/growthcraft/milk/common/tileentity/device/Pancheon.java
@@ -1,11 +1,10 @@
 package growthcraft.milk.common.tileentity.device;
 
-import growthcraft.core.shared.fluids.IFluidTanks;
+import growthcraft.core.shared.tileentity.GrowthcraftTileDeviceBase;
 import growthcraft.core.shared.tileentity.device.DeviceFluidSlot;
 import growthcraft.core.shared.tileentity.device.DeviceProgressive;
 import growthcraft.milk.shared.MilkRegistry;
 import growthcraft.milk.shared.processing.pancheon.IPancheonRecipe;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fluids.FluidStack;
 
 public class Pancheon extends DeviceProgressive<IPancheonRecipe> {
@@ -19,16 +18,11 @@ public class Pancheon extends DeviceProgressive<IPancheonRecipe> {
      * @param fsTop    - top output slot
      * @param fsBottom - bottom output slot
      */
-    public Pancheon(TileEntity te, int fsInput, int fsTop, int fsBottom) {
+    public Pancheon(GrowthcraftTileDeviceBase te, int fsInput, int fsTop, int fsBottom) {
         super(te);
-        if (te instanceof IFluidTanks) {
-            final IFluidTanks ifl = (IFluidTanks) te;
-            this.inputSlot = new DeviceFluidSlot(ifl, fsInput);
-            this.topSlot = new DeviceFluidSlot(ifl, fsTop);
-            this.bottomSlot = new DeviceFluidSlot(ifl, fsBottom);
-        } else {
-            throw new IllegalArgumentException("The provided TileEntity MUST implement the IFluidTanks interface");
-        }
+        this.inputSlot = new DeviceFluidSlot(te, fsInput);
+        this.topSlot = new DeviceFluidSlot(te, fsTop);
+        this.bottomSlot = new DeviceFluidSlot(te, fsBottom);
     }
 
     /**
@@ -38,46 +32,31 @@ public class Pancheon extends DeviceProgressive<IPancheonRecipe> {
      */
     @Override
     protected IPancheonRecipe loadRecipe() {
-        IPancheonRecipe recipe = MilkRegistry.instance().pancheon().getRecipe(inputSlot.get());
-        if (recipe == null) return null;
-        if (!this.topSlot.hasMatchingWithCapacity(recipe.getTopOutputFluid())) return null;
-        if (!this.bottomSlot.hasMatchingWithCapacity(recipe.getBottomOutputFluid())) return null;
-        return recipe;
+        return MilkRegistry.instance().pancheon().getRecipe(inputSlot.get());
     }
 
+    @Override
+    protected boolean canProcess() {
+        IPancheonRecipe recipe = getWorkingRecipe();
+        if(recipe == null) return false;
+        //Checks for input fluids
+        if(!inputSlot.hasEnough(recipe.getInputFluid())) return false;
+        //Checks for output fluids
+        if(!topSlot.hasCapacityFor(recipe.getTopOutputFluid())) return false;
+        if(!bottomSlot.hasCapacityFor(recipe.getBottomOutputFluid())) return false;
+
+        return true;
+    }
 
     /**
      * Complete the process and commit the changes
      */
-    private void commitRecipe() {
-        final IPancheonRecipe recipe = loadRecipe();
-        if (recipe != null) {
-            this.inputSlot.consume(recipe.getInputFluid().amount, true);
-
-            final FluidStack top = recipe.getTopOutputFluid();
-            if (top != null) this.topSlot.fill(top, true);
-
-            final FluidStack bottom = recipe.getBottomOutputFluid();
-            if (bottom != null) this.bottomSlot.fill(bottom, true);
-        }
+    protected void process(IPancheonRecipe recipe) {
+        inputSlot.consume(recipe.getInputFluid(), true);
+        final FluidStack top = recipe.getTopOutputFluid();
+        if (top != null) this.topSlot.fill(top, true);
+        final FluidStack bottom = recipe.getBottomOutputFluid();
+        if (bottom != null) this.bottomSlot.fill(bottom, true);
     }
 
-    /**
-     * Tick update
-     */
-    public void update() {
-        final IPancheonRecipe recipe = getWorkingRecipe();
-        if (recipe != null) {
-            setTimeMax(recipe.getTime());
-            increaseTime();
-            if (time >= timeMax) {
-                resetTime();
-                commitRecipe();
-            }
-            markDirtyAndUpdate(true);
-        } else {
-            if (resetTime())
-            	markDirtyAndUpdate(false);
-        }
-    }
 }

--- a/src/main/java/growthcraft/milk/shared/processing/cheesepress/CheesePressRecipe.java
+++ b/src/main/java/growthcraft/milk/shared/processing/cheesepress/CheesePressRecipe.java
@@ -26,7 +26,7 @@ public class CheesePressRecipe implements ICheesePressRecipe {
     }
 
     @Override
-    public int getTimeMax() {
+    public int getTime() {
         return time;
     }
 

--- a/src/main/java/growthcraft/milk/shared/processing/cheesepress/ICheesePressRecipe.java
+++ b/src/main/java/growthcraft/milk/shared/processing/cheesepress/ICheesePressRecipe.java
@@ -1,14 +1,13 @@
 package growthcraft.milk.shared.processing.cheesepress;
 
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import net.minecraft.item.ItemStack;
 
-public interface ICheesePressRecipe {
+public interface ICheesePressRecipe extends IProcessingRecipeBase {
 
     ItemStack getInputItemStack();
 
     ItemStack getOutputItemStack();
-
-    int getTimeMax();
 
     boolean isMatchingRecipe(ItemStack stack);
 

--- a/src/main/java/growthcraft/milk/shared/processing/cheesevat/CheeseVatRecipe.java
+++ b/src/main/java/growthcraft/milk/shared/processing/cheesevat/CheeseVatRecipe.java
@@ -81,4 +81,9 @@ public class CheeseVatRecipe implements ICheeseVatRecipe {
     public String toString() {
         return String.format("CheeseVatRecipe(output_fluids: %s, output_items: %s, input_fluids: %s, input_items: %s)", outputFluids, outputItems, inputFluids, inputItems);
     }
+
+    @Override
+    public int getTime() {
+        return 0;
+    }
 }

--- a/src/main/java/growthcraft/milk/shared/processing/cheesevat/ICheeseVatRecipe.java
+++ b/src/main/java/growthcraft/milk/shared/processing/cheesevat/ICheeseVatRecipe.java
@@ -2,13 +2,14 @@ package growthcraft.milk.shared.processing.cheesevat;
 
 import java.util.List;
 
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import growthcraft.core.shared.definition.IMultiFluidStacks;
 import growthcraft.core.shared.definition.IMultiItemStacks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 
-public interface ICheeseVatRecipe {
+public interface ICheeseVatRecipe extends IProcessingRecipeBase {
 
     List<FluidStack> getOutputFluidStacks();
 

--- a/src/main/java/growthcraft/milk/shared/processing/churn/ChurnRecipe.java
+++ b/src/main/java/growthcraft/milk/shared/processing/churn/ChurnRecipe.java
@@ -18,6 +18,10 @@ public class ChurnRecipe implements IChurnRecipe {
     }
 
     @Override
+    public int getTime() {
+        return 0;
+    }
+    @Override
     public boolean isValidForRecipe(FluidStack stack) {
         if (stack == null) return false;
         if (!inputFluid.isFluidEqual(stack)) return false;
@@ -53,4 +57,6 @@ public class ChurnRecipe implements IChurnRecipe {
                 FluidFormatString.format(outputFluid),
                 outputItem);
     }
+
+
 }

--- a/src/main/java/growthcraft/milk/shared/processing/churn/IChurnRecipe.java
+++ b/src/main/java/growthcraft/milk/shared/processing/churn/IChurnRecipe.java
@@ -1,9 +1,10 @@
 package growthcraft.milk.shared.processing.churn;
 
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
-public interface IChurnRecipe {
+public interface IChurnRecipe extends IProcessingRecipeBase {
 
     boolean isValidForRecipe(FluidStack stack);
 

--- a/src/main/java/growthcraft/milk/shared/processing/pancheon/IPancheonRecipe.java
+++ b/src/main/java/growthcraft/milk/shared/processing/pancheon/IPancheonRecipe.java
@@ -1,8 +1,9 @@
 package growthcraft.milk.shared.processing.pancheon;
 
+import growthcraft.cellar.shared.processing.common.IProcessingRecipeBase;
 import net.minecraftforge.fluids.FluidStack;
 
-public interface IPancheonRecipe {
+public interface IPancheonRecipe extends IProcessingRecipeBase {
 
     boolean isValidForRecipe(FluidStack stack);
 


### PR DESCRIPTION
I noticed some redundancy in the code for devices. This is a proposition to simplify the creation of new devices. Buffered recipes have been implemented for most devices. This should help for waila compat etc. I still need to make new devices for butter churn, beehives, fish trap etc.