### PR TITLE
Fixed #315 Fishtrap Sound Configuration

### DIFF
--- a/src/main/java/growthcraft/fishtrap/common/tileentity/TileEntityFishtrap.java
+++ b/src/main/java/growthcraft/fishtrap/common/tileentity/TileEntityFishtrap.java
@@ -48,7 +48,6 @@ public class TileEntityFishtrap extends TileEntity implements ITickable, ICapabi
     private ItemStackHandler handlerOutput;
     private ItemStackHandler handlerInput;
 
-
     public TileEntityFishtrap() {
         this.cooldown = 0;
         this.randomMaxCooldown = intMaxCooldown;
@@ -94,8 +93,9 @@ public class TileEntityFishtrap extends TileEntity implements ITickable, ICapabi
                 }
             }
         }
-        GrowthcraftPlaySound.onlyNearByPlayers(this.world, pos, SoundEvents.BLOCK_TRIPWIRE_CLICK_ON, SoundCategory.BLOCKS, 3);
-
+        if (GrowthcraftFishtrapConfig.isFishtrapSoundEnabled()) {
+            GrowthcraftPlaySound.onlyNearByPlayers(this.world, pos, SoundEvents.BLOCK_TRIPWIRE_CLICK_ON, SoundCategory.BLOCKS, GrowthcraftFishtrapConfig.getFishtrapSoundRange());
+        }
     }
 
     public boolean hasBait() {
@@ -147,7 +147,6 @@ public class TileEntityFishtrap extends TileEntity implements ITickable, ICapabi
             remainder = handler.insertItem(slot, stack, simulate);
             if (remainder == ItemStack.EMPTY) break;
         }
-        //markDirtyAndUpdate();
         return remainder;
     }
 
@@ -304,13 +303,4 @@ public class TileEntityFishtrap extends TileEntity implements ITickable, ICapabi
         return "growthcraft_fishtrap:fishtrap";
     }
 
-/*    @Override
-    public void onInventoryChanged(IInventory inv, int index) {
-        super.onInventoryChanged(inv, index);
-        if (index == 0) {
-            markDirty();
-        } else if (index > 0) {
-            markDirtyAndUpdate();
-        }
-    }*/
 }

--- a/src/main/java/growthcraft/fishtrap/shared/config/GrowthcraftFishtrapConfig.java
+++ b/src/main/java/growthcraft/fishtrap/shared/config/GrowthcraftFishtrapConfig.java
@@ -13,23 +13,22 @@ import java.util.List;
 
 public class GrowthcraftFishtrapConfig {
 
-    private static Configuration configuration;
-
     private static final String CATEGORY_GENERAL = "general";
     private static final String CATEGORY_FISHTRAP = "fishtrap";
-
-    private GrowthcraftFishtrapConfig() {
-    }
-
     public static boolean isDebug = false;
     public static String logLevel = "info";
-
     public static boolean baitRequired = false;
     public static boolean strictBait = false;
     public static List<String> FISHTRAP_BAIT_TABLE = new ArrayList<String>() {{
         add("minecraft:rotten_flesh");
         add("minecraft:fish");
     }};
+    private static Configuration configuration;
+    private static boolean enableFishtrapSound = true;
+    private static int fishtrapSoundRange = 3;
+
+    private GrowthcraftFishtrapConfig() {
+    }
 
     public static void preInit(FMLPreInitializationEvent e) {
         File directory = e.getModConfigurationDirectory();
@@ -75,6 +74,21 @@ public class GrowthcraftFishtrapConfig {
                 "Only bait in the authorizedFishBait list will be allowed."
         );
 
+        enableFishtrapSound = configuration.getBoolean(
+                "enableFishtrapSound",
+                CATEGORY_FISHTRAP,
+                enableFishtrapSound,
+                "Play a sound notifying nearby players that the fishtrap caught something"
+        );
+
+        fishtrapSoundRange = configuration.getInt(
+                "fishtrapSoundRange",
+                CATEGORY_FISHTRAP,
+                fishtrapSoundRange,
+                1, 10,
+                "Set the range that the fishtrap sounds can be heard. This is relative to the fishtrap BlockPos."
+        );
+
         FISHTRAP_BAIT_TABLE = Arrays.asList(configuration.getStringList(
                 "fishtrap_bait_list",
                 CATEGORY_FISHTRAP,
@@ -89,6 +103,14 @@ public class GrowthcraftFishtrapConfig {
         if (logLevel.equalsIgnoreCase("debug")) {
             isDebug = true;
         }
+    }
+
+    public static boolean isFishtrapSoundEnabled() {
+        return enableFishtrapSound;
+    }
+
+    public static int getFishtrapSoundRange() {
+        return fishtrapSoundRange;
     }
 
 }


### PR DESCRIPTION
While I couldn't reproduce the bug reported, added configuration settings to disable
the fishtrap sounds and/or change the range from the default offeset of 3 based on
the BlockPos of the block.