### PR TITLE
Fixed #80 Transferring items out of Growthcraft device inventories now stack

### DIFF
--- a/src/main/java/growthcraft/core/shared/inventory/GrowthcraftContainer.java
+++ b/src/main/java/growthcraft/core/shared/inventory/GrowthcraftContainer.java
@@ -16,6 +16,8 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import javax.annotation.Nullable;
+
 public class GrowthcraftContainer extends Container {
     protected static final int SLOT_W = 18;
     protected static final int SLOT_H = 18;
@@ -44,31 +46,35 @@ public class GrowthcraftContainer extends Container {
         int start = -1;
         int end = -1;
 
-        for (Object sub : inventorySlots) {
-            if (slotClass.isInstance(sub)) {
-                final Slot subSlot = (Slot) sub;
+        for (Slot slot : inventorySlots) {
+            if (slotClass.isInstance(slot)) {
                 if (start < 0) {
-                    start = subSlot.slotNumber;
+                    start = slot.slotNumber;
                 }
-                end = subSlot.slotNumber;
+                end = slot.slotNumber;
             }
         }
         if (start <= -1 || end <= -1) return false;
 
-        boolean merged = false;
-        for (int i = start; i <= end; ++i) {
-            // Stop iterating if the stack has been successfully merged
+        boolean merged = mergeWithComparativeSlot(start, end, stack, stack);
+
+        if(!merged) {
+            merged = mergeWithComparativeSlot(start, end, stack, null);
+        }
+
+        return merged;
+    }
+
+    private boolean mergeWithComparativeSlot(int startSlotID, int endSlotID, ItemStack stack, @Nullable ItemStack matchStack) {
+        for (int i = startSlotID; i <= endSlotID; ++i) {
             if (stack.isEmpty()) break;
-            // Get the object at the given index
-            final Object obj = inventorySlots.get(i);
-            // Determine if the slot is the expected (in case the slots are interleaved)
-            if (slotClass.isInstance(obj)) {
-                final Slot subSlot = (Slot) obj;
-                // try to merge it
-                merged |= mergeWithSlot(subSlot, stack);
+            final Slot subSlot = inventorySlots.get(i);
+            if ( (matchStack == null && subSlot.isItemValid(stack))
+                    || (ItemStack.areItemsEqual(subSlot.getStack(), matchStack) ) ) {
+                return mergeWithSlot(subSlot, stack);
             }
         }
-        return merged;
+        return false;
     }
 
     public boolean mergeWithPlayer(ItemStack stack) {
@@ -89,10 +95,6 @@ public class GrowthcraftContainer extends Container {
 
     @Override
     public ItemStack transferStackInSlot(EntityPlayer player, int index) {
-//		if (Platform.isClient())
-//		{
-//			return ItemStack.EMPTY;
-//		}
 
         final Slot s = getSlot(index);
         ItemStack itemstack = ItemStack.EMPTY;


### PR DESCRIPTION
There was a bug due to how we were transferring items from device inventory to player inventory that resulted in the ItemStack being placed in the first available Slot instead of trying to stack with a slot that had a matching ItemStack.