### PR TITLE
Fix fruit press z-fighting with minimum liquid

### DIFF
--- a/src/main/resources/assets/growthcraft_cellar/models/block/fruit_press.json
+++ b/src/main/resources/assets/growthcraft_cellar/models/block/fruit_press.json
@@ -181,7 +181,7 @@
 		},
 		{
 			"name": "base_bottom",
-			"from": [1, 3, 1],
+			"from": [1, 2.99, 1],
 			"to": [15, 4, 15],
 			"rotation": {
 				"angle": 0,


### PR DESCRIPTION
Lowered the base of the model that is in contact with liquid by 0.01 to avoid stitching between the block and rendered liquid's textures.