### PR TITLE
Added CraftTweaker integration for BrewKEttle, FermentBarrel and FruitPress

### DIFF
--- a/src/main/java/growthcraft/cellar/shared/processing/brewing/BrewingRegistry.java
+++ b/src/main/java/growthcraft/cellar/shared/processing/brewing/BrewingRegistry.java
@@ -109,4 +109,8 @@ public class BrewingRegistry {
     public boolean isFallbackRecipe(IBrewingRecipe recipe) {
         return (recipe instanceof BrewingFallbackRecipe) && !(recipe instanceof BrewingRecipe);
     }
+
+    public void removeRecipe(FluidStack toFluidStack, ItemStack toStack, boolean requiresLid) {
+        recipes.removeIf(r -> r.matchesRecipe(toFluidStack, toStack, requiresLid));
+    }
 }

--- a/src/main/java/growthcraft/cellar/shared/processing/fermenting/FermentingRegistry.java
+++ b/src/main/java/growthcraft/cellar/shared/processing/fermenting/FermentingRegistry.java
@@ -125,4 +125,8 @@ public class FermentingRegistry {
     public boolean isFallbackRecipe(IFermentationRecipe recipe) {
         return (recipe instanceof FermentationFallbackRecipe) && !(recipe instanceof FermentationRecipe);
     }
+
+    public void removeRecipe(FluidStack inputFluid, ItemStack inputStack) {
+        recipes.removeIf(r -> r.matchesRecipe(inputFluid, inputStack));
+    }
 }

--- a/src/main/java/growthcraft/cellar/shared/processing/pressing/PressingRegistry.java
+++ b/src/main/java/growthcraft/cellar/shared/processing/pressing/PressingRegistry.java
@@ -24,6 +24,10 @@ public class PressingRegistry {
         addRecipe(new PressingRecipe(MultiStacksUtil.toMultiItemStacks(inputStack), resultFluid, time, residue));
     }
 
+    public void removeRecipe(ItemStack input) {
+        recipes.removeIf(r -> r.matchesRecipe(input));
+    }
+
     public IPressingRecipe getPressingRecipe(ItemStack itemstack) {
         if (itemstack == null) return null;
 

--- a/src/main/java/growthcraft/core/GrowthcraftCore.java
+++ b/src/main/java/growthcraft/core/GrowthcraftCore.java
@@ -1,5 +1,6 @@
 package growthcraft.core;
 
+import crafttweaker.CraftTweakerAPI;
 import growthcraft.core.common.CommonProxy;
 import growthcraft.core.common.Init;
 import growthcraft.core.common.creativetabs.TabGrowthcraft;
@@ -11,6 +12,9 @@ import growthcraft.core.shared.compat.rustic.InitRustic;
 import growthcraft.core.shared.config.GrowthcraftCoreConfig;
 import growthcraft.core.shared.item.recipes.ShapelessItemComparableRecipe;
 import growthcraft.core.shared.item.recipes.ShapelessMultiRecipe;
+import growthcraft.tweaker.BrewKettle;
+import growthcraft.tweaker.FermentBarrel;
+import growthcraft.tweaker.FruitPress;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraftforge.client.event.ModelRegistryEvent;
@@ -76,6 +80,10 @@ public class GrowthcraftCore {
 
         RecipeSorter.register("minecraft:shapeless_comparator", ShapelessItemComparableRecipe.class, Category.SHAPELESS, "after:minecraft:shapeless");
         RecipeSorter.register("minecraft:shapeless_multi", ShapelessMultiRecipe.class, Category.SHAPELESS, "after:minecraft:shapeless");
+
+        CraftTweakerAPI.registerClass(BrewKettle.class);
+        CraftTweakerAPI.registerClass(FermentBarrel.class);
+        CraftTweakerAPI.registerClass(FruitPress.class);
     }
 
     @SubscribeEvent

--- a/src/main/java/growthcraft/tweaker/BrewKettle.java
+++ b/src/main/java/growthcraft/tweaker/BrewKettle.java
@@ -1,0 +1,37 @@
+package growthcraft.tweaker;
+
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.liquid.ILiquidStack;
+import growthcraft.cellar.shared.CellarRegistry;
+import growthcraft.cellar.shared.processing.brewing.BrewingRecipe;
+import growthcraft.cellar.shared.processing.common.Residue;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.growthcraft.BrewKettle")
+public class BrewKettle {
+
+
+    @ZenMethod
+    public static void addRecipe(ILiquidStack pInputFluid, IIngredient pInputItem,
+                                 ILiquidStack pOutputFluid, boolean requiresLid, int craftingTime, IItemStack residue, float residuePerInput) {
+        DummyAction.apply(() ->
+                CellarRegistry.instance().brewing().addRecipe(
+                        new BrewingRecipe(
+                                Utils.toFluidStack(pInputFluid),
+                                Utils.toMultiStack(pInputItem),
+                                Utils.toFluidStack(pOutputFluid),
+                                requiresLid,
+                                craftingTime,
+                                new Residue(Utils.toStack(residue), residuePerInput)
+                        )
+                )
+        );
+    }
+
+    @ZenMethod
+    public static void removeRecipe(ILiquidStack pInputFluid, IItemStack pInputItem, boolean requiresLid) {
+        DummyAction.apply(() -> CellarRegistry.instance().brewing().removeRecipe(Utils.toFluidStack(pInputFluid), Utils.toStack(pInputItem), requiresLid));
+    }
+}

--- a/src/main/java/growthcraft/tweaker/DummyAction.java
+++ b/src/main/java/growthcraft/tweaker/DummyAction.java
@@ -1,0 +1,15 @@
+package growthcraft.tweaker;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.IAction;
+
+public interface DummyAction extends IAction {
+    @Override
+    public default String describe() {
+        return "";
+    }
+
+    public static void apply(DummyAction action) {
+        CraftTweakerAPI.apply(action);
+    }
+}

--- a/src/main/java/growthcraft/tweaker/FermentBarrel.java
+++ b/src/main/java/growthcraft/tweaker/FermentBarrel.java
@@ -1,0 +1,31 @@
+package growthcraft.tweaker;
+
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.liquid.ILiquidStack;
+import growthcraft.cellar.shared.CellarRegistry;
+import growthcraft.cellar.shared.processing.fermenting.FermentationRecipe;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.growthcraft.FermentBarrel")
+public class FermentBarrel {
+    @ZenMethod
+    public static void addRecipe(ILiquidStack pInputFluidStack, IIngredient pFermentingItem, ILiquidStack pOutputFluidStack, int craftingTime) {
+        DummyAction.apply(() ->
+                CellarRegistry.instance().fermenting().addRecipe(
+                        new FermentationRecipe(
+                                Utils.toMultiFluid(pInputFluidStack),
+                                Utils.toMultiStack(pFermentingItem),
+                                Utils.toFluidStack(pOutputFluidStack),
+                                craftingTime
+                        )
+                )
+        );
+    }
+
+    @ZenMethod
+    public static void removeRecipe(ILiquidStack pInputFluidStack, IItemStack pFermentingItem) {
+        DummyAction.apply(() -> CellarRegistry.instance().fermenting().removeRecipe(Utils.toFluidStack(pInputFluidStack), Utils.toStack(pFermentingItem)));
+    }
+}

--- a/src/main/java/growthcraft/tweaker/FruitPress.java
+++ b/src/main/java/growthcraft/tweaker/FruitPress.java
@@ -1,0 +1,33 @@
+package growthcraft.tweaker;
+
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.liquid.ILiquidStack;
+import growthcraft.cellar.shared.CellarRegistry;
+import growthcraft.cellar.shared.processing.common.Residue;
+import growthcraft.cellar.shared.processing.pressing.PressingRecipe;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.growthcraft.FruitPress")
+public class FruitPress {
+
+    @ZenMethod
+    public static void addRecipe(IIngredient input, int craftingTime, ILiquidStack product, IItemStack residue, float residuePerInput) {
+        DummyAction.apply(() ->
+                CellarRegistry.instance().pressing().addRecipe(
+                        new PressingRecipe(
+                                Utils.toMultiStack(input),
+                                Utils.toFluidStack(product),
+                                craftingTime,
+                                new Residue(Utils.toStack(residue), residuePerInput)
+                        )
+                )
+        );
+    }
+
+    @ZenMethod
+    public static void removeRecipe(IItemStack input) {
+        DummyAction.apply(() -> CellarRegistry.instance().pressing().removeRecipe(Utils.toStack(input)));
+    }
+}

--- a/src/main/java/growthcraft/tweaker/Utils.java
+++ b/src/main/java/growthcraft/tweaker/Utils.java
@@ -1,0 +1,53 @@
+package growthcraft.tweaker;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.api.item.IIngredient;
+import crafttweaker.api.item.IItemStack;
+import crafttweaker.api.liquid.ILiquidStack;
+import growthcraft.core.shared.definition.IMultiFluidStacks;
+import growthcraft.core.shared.definition.IMultiItemStacks;
+import growthcraft.core.shared.fluids.MultiFluidStacks;
+import growthcraft.core.shared.item.MultiItemStacks;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.util.stream.Collectors;
+
+public class Utils {
+
+    public static FluidStack toFluidStack(ILiquidStack liquidStack) {
+        return FluidRegistry.getFluidStack(liquidStack.getName(), liquidStack.getAmount());
+    }
+
+    public static IMultiItemStacks toMultiStack(IIngredient ingredient) {
+        return new MultiItemStacks(ingredient.getItems().stream().map(Utils::toStack).collect(Collectors.toList()));
+    }
+
+    public static ItemStack toStack(IItemStack ctStack) {
+        return toStackTrim(ctStack, false);
+    }
+
+    public static ItemStack toStackTrim(IItemStack ctStack, boolean trim) {
+        if (ctStack == null)
+            return ItemStack.EMPTY;
+        else {
+            Object internal = ctStack.getInternal();
+            if (!(internal instanceof ItemStack))
+                CraftTweakerAPI.getLogger().logError("Not a valid item stack: " + ctStack);
+            else if (trim) {
+                ItemStack t = ((ItemStack) internal);
+                if (t.getCount() > 1) {
+                    CraftTweakerAPI.getLogger().logWarning("Stack size not supported, reduced to one item.");
+                    t.setCount(1);
+                }
+                return t;
+            }
+            return ((ItemStack) internal);
+        }
+    }
+
+    public static IMultiFluidStacks toMultiFluid(ILiquidStack liquidStack) {
+        return new MultiFluidStacks(liquidStack.getLiquids().stream().map(Utils::toFluidStack).collect(Collectors.toList()));
+    }
+}


### PR DESCRIPTION
ZenScript api:
+ `mods.growthcraft.BrewKettle`
   + `addRecipe(ILiquidStack pInputFluid, IIngredient pInputItem, ILiquidStack pOutputFluid, boolean requiresLid, `
   `int craftingTime, IItemStack residue, float residuePerInput)`
   + `removeRecipe(ILiquidStack pInputFluid, IItemStack pInputItem, boolean requiresLid) `
+ `mods.growthcraft.FermentBarrel`
   + `addRecipe(ILiquidStack pInputFluidStack, IIngredient pFermentingItem, ILiquidStack pOutputFluidStack, `
   `int craftingTime)`
   + `removeRecipe(ILiquidStack pInputFluidStack, IItemStack pFermentingItem)`
+ `mods.growthcraft.FruitPress`
   + `addRecipe(IIngredient input, int craftingTime, ILiquidStack product, IItemStack residue, float residuePerInput)`
   + `removeRecipe(IItemStack input)`