### PR TITLE
Increased hunger saturation of Ice Cream and Yogurt

### DIFF
--- a/src/main/java/growthcraft/milk/common/Init.java
+++ b/src/main/java/growthcraft/milk/common/Init.java
@@ -181,8 +181,8 @@ public class Init {
         GrowthcraftMilkItems.cheeseCloth = new ItemDefinition(new ItemCheeseCloth("cheese_cloth"));
         GrowthcraftMilkItems.starterCulture = new ItemDefinition(new ItemStarterCulture("starter_culture"));
         GrowthcraftMilkItems.butter = new ItemDefinition(new ItemButter("butter", 2, 0.3F, false));
-        GrowthcraftMilkItems.iceCream = new ItemDefinition(new ItemIceCream("ice_cream", 2, 0.3F, false));
-        GrowthcraftMilkItems.yogurt = new ItemDefinition(new ItemYogurt("yogurt", 2, 0.3F, false));
+        GrowthcraftMilkItems.iceCream = new ItemDefinition(new ItemIceCream("ice_cream", 4, 0.4F, false));
+        GrowthcraftMilkItems.yogurt = new ItemDefinition(new ItemYogurt("yogurt", 3, 0.3F, false));
         GrowthcraftMilkItems.knife = new ItemDefinition(new ItemKnife("knife"));
         GrowthcraftMilkItems.agedCheeseSlice = new ItemDefinition(new ItemAgedCheeseSlice("cheese_aged_slice", 3, 0.3F, false));
         GrowthcraftMilkItems.agedCheeseBlockItem = new ItemDefinition(new ItemBlockCheeseBlock<AgedCheeseTypes>(GrowthcraftMilkBlocks.agedCheeseBlock.getBlock(), AgedCheeseTypes.values()));

--- a/src/main/java/growthcraft/milk/common/item/ItemIceCream.java
+++ b/src/main/java/growthcraft/milk/common/item/ItemIceCream.java
@@ -62,7 +62,7 @@ public class ItemIceCream extends ItemFood {
             if (entityplayer instanceof EntityPlayerMP) {
                 CriteriaTriggers.CONSUME_ITEM.trigger((EntityPlayerMP) entityplayer, stack);
             }
-            // Add a bowl to the player inventory as a result of consuming the ItemCheeseBowl
+            // Add a bowl to the player inventory as a result of consuming the ItemIceCream
             entityplayer.inventory.addItemStackToInventory(new ItemStack(Items.BOWL));
         }
 

--- a/src/main/java/growthcraft/milk/common/item/ItemYogurt.java
+++ b/src/main/java/growthcraft/milk/common/item/ItemYogurt.java
@@ -62,7 +62,7 @@ public class ItemYogurt extends ItemFood {
             if (entityplayer instanceof EntityPlayerMP) {
                 CriteriaTriggers.CONSUME_ITEM.trigger((EntityPlayerMP) entityplayer, stack);
             }
-            // Add a bowl to the player inventory as a result of consuming the ItemCheeseBowl
+            // Add a bowl to the player inventory as a result of consuming the ItemYogurt
             entityplayer.inventory.addItemStackToInventory(new ItemStack(Items.BOWL));
         }
 


### PR DESCRIPTION
This PR Addresses #119, but I wouldn't consider it a full "fix".

I made Ice Cream restore **2** instead of **1** hunger bar and increased the saturation from **0.3F** to **0.4F**.
Yogurt only got **1.5** instead of **1** hunger bar, as it's more cheap to craft and I didn't touch Ricotta at all as I think 1 hunger bar is enough, considering the cheap crafting.

Let me know if you'd like me to change any of the values!

**After this PR, I'll create a Release PR including a draft changelog.**

PS: Should I remove the sonarcube steps from the build workflow so it no longer fails? 🤔